### PR TITLE
try to build dependencies that let the url_shim work

### DIFF
--- a/harmonizer/package-lock.json
+++ b/harmonizer/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apollo/composition": "=2.0.0-alpha.3",
         "fast-text-encoding": "^1.0.3",
+        "text-encoding": "^0.7.0",
         "whatwg-url": "^11.0.0"
       },
       "devDependencies": {
@@ -478,6 +479,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained"
+    },
     "node_modules/tr46": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
@@ -873,6 +880,11 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
     },
     "tr46": {
       "version": "3.0.0",

--- a/harmonizer/package.json
+++ b/harmonizer/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@apollo/composition": "=2.0.0-alpha.3",
     "fast-text-encoding": "^1.0.3",
+    "text-encoding": "^0.7.0",
     "whatwg-url": "^11.0.0"
   },
   "peerDependencies": {

--- a/harmonizer/rollup.config.js
+++ b/harmonizer/rollup.config.js
@@ -6,6 +6,17 @@ import path from 'path';
 
 export default [
   {
+    input: path.resolve(__dirname, './node_modules/text-encoding/index.js'),
+    output: {
+      name: 'text_encoding',
+      file: path.resolve(__dirname, './dist/text_encoding.js'),
+      format: 'iife',
+      globals: {},
+    },
+    external: [],
+    plugins: [json(), nodePolyfills(), resolve(), commonjs()],
+  },
+  {
     input: path.resolve(__dirname, './js/url_polyfill.mjs'),
     output: {
       name: 'url_shim',

--- a/harmonizer/src/lib.rs
+++ b/harmonizer/src/lib.rs
@@ -110,6 +110,11 @@ exports = {};
         )
         .expect("unable to initialize composition runtime environment");
 
+    // Load encoding polyfill for url_shim
+    runtime
+        .execute_script("text_encoding.js", include_str!("../dist/text_encoding.js"))
+        .expect("unable to evaluate encoding module");
+
     // Load URL polyfill
     runtime
         .execute_script("url_shim.js", include_str!("../dist/url_shim.js"))


### PR DESCRIPTION
```
ignition@ignition-apollo federation-rs % rustc --version
rustc 1.58.0 (02072b482 2022-01-11)
```

```
ignition@ignition-apollo federation-rs % node --version
v16.13.2
```

```
ignition@ignition-apollo federation-rs % cargo t -p harmonizer
   Compiling harmonizer v2.0.0-alpha.3 (/Users/ignition/projects/apollo/federation-rs/harmonizer)
warning: Updating bridge.js
    Finished test [unoptimized + debuginfo] target(s) in 5.76s
     Running unittests (target/debug/deps/harmonizer-ae3430ac6a6318e4)

running 1 test
test tests::it_works ... FAILED

failures:

---- tests::it_works stdout ----
cargo:rerun-if-changed=/Users/ignition/.cargo/registry/src/github.com-1ecc6299db9ec823/deno_core-0.114.0/00_primordials.js
cargo:rerun-if-changed=/Users/ignition/.cargo/registry/src/github.com-1ecc6299db9ec823/deno_core-0.114.0/01_core.js
cargo:rerun-if-changed=/Users/ignition/.cargo/registry/src/github.com-1ecc6299db9ec823/deno_core-0.114.0/02_error.js
thread 'tests::it_works' panicked at 'called `Result::unwrap()` on an `Err` value: BuildErrors { build_errors: [BuildError { message: None, code: None, type: Composition }] }', harmonizer/src/lib.rs:193:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::it_works

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

error: test failed, to rerun pass '-p harmonizer --lib'
```