### PR TITLE
Create github_projects_tagger.yml

### DIFF
--- a/.github/workflows/github_projects_tagger.yml
+++ b/.github/workflows/github_projects_tagger.yml
@@ -1,0 +1,19 @@
+name: GitHub Projects Tagger
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: abernix/github-issue-pull-api-hook@v1.0.0
+        with:
+          # These are both set in Org level secrets and work on a safe-listed
+          # set of repositories that affect the Polaris team.  This allows them to
+          # be updated in a single place.  If you want a NEW repo to work, you'll
+          # need an org admin to add it as a repo to (both) the existing secrets.
+          # https://github.com/organizations/apollographql/settings/secrets/actions
+          api_url: ${{ secrets.POLARIS_TAGGER_API_URL }}
+          bearer_token: ${{ secrets.POLARIS_TAGGER_BEARER_TOKEN }}


### PR DESCRIPTION
This accomplishes adding new issues to our Project board automatically for Triage and planning purposes in our team.

Closes #22