### PR TITLE
chore: add `assertion_lines` to `insta` snaps

### DIFF
--- a/harmonizer-0/src/snapshots/harmonizer_0__tests__it_works.snap
+++ b/harmonizer-0/src/snapshots/harmonizer_0__tests__it_works.snap
@@ -1,6 +1,6 @@
 ---
 source: harmonizer-0/src/lib.rs
-assertion_line: 141
+assertion_line: 140
 expression: "harmonize(vec![SubgraphDefinition ::\n               new(\"users\", \"undefined\",\n                   \"\n            type User @key(fields: \\\"id\\\") {\n              id: ID\n              name: String\n            }\n\n            type Query {\n              users: [User!]\n            }\n          \"),\n               SubgraphDefinition ::\n               new(\"movies\", \"undefined\",\n                   \"\n            type Movie {\n              title: String\n              name: String\n            }\n\n            extend type User {\n              favorites: [Movie!]\n            }\n\n            type Query {\n              movies: [Movie!]\n            }\n          \")]).unwrap().supergraph_sdl"
 
 ---

--- a/router-bridge/src/snapshots/router_bridge__introspect__tests__it_works.snap
+++ b/router-bridge/src/snapshots/router_bridge__introspect__tests__it_works.snap
@@ -1,5 +1,6 @@
 ---
 source: router-bridge/src/introspect.rs
+assertion_line: 112
 expression: "serde_json::to_string(&introspected).unwrap()"
 
 ---

--- a/router-bridge/src/snapshots/router_bridge__plan__tests__it_works.snap
+++ b/router-bridge/src/snapshots/router_bridge__plan__tests__it_works.snap
@@ -1,5 +1,6 @@
 ---
 source: router-bridge/src/plan.rs
+assertion_line: 174
 expression: "serde_json::to_string_pretty(&plan::<serde_json::Value>(OperationalContext{schema:\n                                                                               SCHEMA.to_string(),\n                                                                           query:\n                                                                               QUERY.to_string(),\n                                                                           operation_name:\n                                                                               \"\".to_string(),},\n                                                        QueryPlanOptions::default()).unwrap()).unwrap()"
 
 ---


### PR DESCRIPTION
Per the new version of `insta`:

    Insta now memorizes assertion line numbers in snapshots. While these will
    quickly be old, they are often useful when reviewing snapshots immediately
    after creation with cargo-insta.

Ref: https://github.com/mitsuhiko/insta/blob/e8f3f2782e24b4eb5f256f94bbd98048d4a716ba/CHANGELOG.md#180
Ref: https://github.com/mitsuhiko/insta/blob/966320e81912b3f92407a0ff8991ba7b6233c9c9/src/output.rs#L64