### PR TITLE
router-bridge: Introduce native `graphql` (JS) `validate` to the `plan`

### DIFF
--- a/router-bridge/js-src/plan.ts
+++ b/router-bridge/js-src/plan.ts
@@ -1,4 +1,4 @@
-import { ExecutionResult, parse } from "graphql";
+import { ExecutionResult, parse, validate } from "graphql";
 import { QueryPlanner, QueryPlan } from "@apollo/query-planner";
 
 import {
@@ -14,6 +14,15 @@ export function plan(
   try {
     const composedSchema = buildSchema(schemaString);
     const operationDocument = parse(operationString);
+    const graphqlJsSchema = composedSchema.toGraphQLJSSchema();
+
+    // Federation does some validation, but not all.  We need to do
+    // all default validations that are provided by GraphQL.
+    const validationErrors = validate(graphqlJsSchema, operationDocument);
+    if (validationErrors.length > 0) {
+      return { errors: validationErrors };
+    }
+
     const operation = operationFromDocument(
       composedSchema,
       operationDocument,


### PR DESCRIPTION
While Federation's `buildQueryPlan` function does a fair bit of validation in order to properly build our plan (and leverages `graphql`'s [`validate`] function do most of that), it *does not* do all of the [default validations] that are specified.

To be thorough, we must call `validate`, as we did [prior] to updating to the new Federation v2 alpha query planner.

This also introduces a number of tests which exercise specific validations which we know as of today are not part of federation:

 - `invalid_graphql_validation_1_is_caught`: [`NoFragmentCyclesRule`](https://github.com/graphql/graphql-js/blob/95dac43fd4bff037e06adaa7cfb44f497bca94a7/src/validation/rules/NoFragmentCyclesRule.ts)
 - `invalid_graphql_validation_2_is_caught`: [`ScalarLeafsRule`](https://github.com/graphql/graphql-js/blob/95dac43fd4bff037e06adaa7cfb44f497bca94a7/src/validation/rules/ScalarLeafsRule.ts)
 - `invalid_graphql_validation_3_is_caught`: [`NoUnusedFragmentsRule`](https://github.com/graphql/graphql-js/blob/95dac43fd4bff037e06adaa7cfb44f497bca94a7/src/validation/rules/NoUnusedFragmentsRule.ts)

I chose three random but different types to make sure we're capturing it.

[prior]: https://github.com/apollographql/federation/commit/9cb220135d776043acfe0cee411277a8f2ce0976
[`validate`]: https://github.com/graphql/graphql-js/blob/95dac43fd4bff037e06adaa7cfb44f497bca94a7/src/validation/validate.ts#L38
[default validations]: https://github.com/graphql/graphql-js/blob/95dac43fd4bff037e06adaa7cfb44f497bca94a7/src/validation/specifiedRules.ts#L76-L103

Closes: https://github.com/apollographql/federation-rs/issues/25