### PR TITLE
chore: creates many RELEASE_CHECKLIST.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,29 @@
 # `federation-rs`
 
-This repository is responsible for all of the [deno](https://deno.land)-powered TypeScript <--> Rust interop needed for the [`harmonizer`](https://crates.io/crates/harmonizer) crate.
+This repository is responsible for all of the [deno](https://deno.land)-powered TypeScript <--> Rust interop. Currently this includes composition and query planning.
 
 ## Branch Strategy
 
 This repository has one long-running branch, `main`. The [`federation`](https://github.com/apollographql/federation) repository itself maintains two separate branches, `version-0.x` for Federation 1 and `main` for Federation 2.
 
-## `harmonizer`
+## Packages
 
-The `harmonizer` crate is a library that provides the federation composition algorithm to the rest of Apollo's Rust ecosystem.
+### `harmonizer`
 
-### `harmonizer-0` and `harmonizer-2`
+**The `harmonizer` crate is a library that provides the federation composition algorithm to the rest of Apollo's Rust ecosystem.**
+
+#### `harmonizer-0` and `harmonizer-2`
 
 You'll realize that there are two workspace crates for `harmonizer` in this repository: `harmonizer-0` and `harmonizer-2`. These will both be built by default when working in this repository, and they both use the same `harmonizer_build.rs` file to build. Since these two versions are both published as the [`harmonizer`](https://crates.io/crates/harmonizer) crate, `harmonizer_build.rs` takes care of updating the versions in the `Cargo.toml` and `package.json` files to match the corresponding JavaScript package (`@apollo/federation` for `harmonizer-0` and `@apollo/composition` for `harmonizer-2`). It then creates a `Cargo.publish.toml` that is _almost_ identical to the real `Cargo.toml` except it changes `package.name` from `harmonizer-x` to `harmonizer` and changes `package.publish` from `false` to `true`.
 
-### Releasing `harmonizer`
+### `supergraph`
 
-When a new version of `@apollo/composition` is published, Renovate opens a PR against `main` that bumps the dependency in `harmonizer-2`, and automatically merges it. Then a CircleCI job requests approval in Slack for cutting a release of `harmonizer`, which, when approved, tags, builds, and publishes `harmonizer` to crates.io at the proper 2.x version.
+**The `supergraph` crate is a binary that provides the federation composition algorithm as a CLI, primarily for integration with [rover](https://github.com/apollographql/rover).**
 
-When a new version of `@apollo/federation` is published, Renovate opens a PR against `main` that bumps the dependency in `harmonizer-0`, and automatically merges it. Then a CircleCI job requests approval in Slack for cutting a release of `harmonizer`, which, when approved, tags, builds, and publishes `harmonizer` to crates.io at the proper 0.x version.
-
-## `supergraph`
-
-The `supergraph` crate is a binary that provides the federation composition algorithm as a CLI, primarily for integration with [rover](https://github.com/apollographql/rover).
-
-### `supergraph-0` and `supergraph-2`
+#### `supergraph-0` and `supergraph-2`
 
 Much like `harmonizer`, there are two sibling versions of `supergraph`. This works exactly the same as `harmonizer` except that `supergraph` is never published to crates.io. Their version numbers are updated when `harmonizer` is built, and only one version is selected when creating the `stage` workspace.
 
-### Releasing `supergraph`
+### `apollo-federation-types`
 
-When `harmonizer` is published to crates.io, the `supergraph` binary is built for multiple architectures and uploaded to this repository's GitHub Releases page.
-
-## `apollo-federation-types`
-
-The `apollo-federation-types` crate is a helper crate that is used across Apollo's federation ecosystem (primarily in our [blazing-fast](https://www.apollographql.com/blog/announcement/backend/apollo-router-our-graphql-federation-runtime-in-rust/) [router](https://github.com/apollographql/router), [rover](https://github.com/apollographql/rover)), in both versions of `harmonizer` and their respective `supergraph` CLI.
-
-### Publish Strategy
-
-The helper crates are only ever released when a new version of harmonizer is published. xtask manages the creation of a "/stage" directory that only contains one version of harmonizer, then all of the crates are published together.
+The `apollo-federation-types` crate provides types for all versions of `harmonizer` and `supergraph`, and is used by [Rover](https://github.com/apollographql/rover) to read the output from the `supergraph` binary.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,16 @@
+# Definitely Not a Release Checklist
+
+🤖 This document does not contain the droids you are looking for.
+
+`federation-rs` is a monorepo that orchestrates publishing multiple packages, sometimes all at once.
+
+The following table describes the packages that will be published by following a specific release checklist in this repository.
+
+| package/binary | version | release checklist |
+| --- | --- | --- |
+| `apollo-federation-types` | any | [`./apollo-federation-types`](./apollo-federation-types/RELEASE_CHECKLIST.md) |
+| `harmonizer` | v0.x.x | [`./harmonizer-0`](./harmonizer-0/RELEASE_CHECKLIST.md) |
+| `harmonizer` | v2.x.x | [`./harmonizer-2`](./harmonizer-2/RELEASE_CHECKLIST.md) |
+| `router-bridge` | any | [`./router-bridge`](./router-bridge/RELEASE_CHECKLIST.md) |
+| `supergraph` | v0.x.x | [`./harmonizer-0`](./harmonizer-0/RELEASE_CHECKLIST.md) |
+| `supergraph` | v2.x.x | [`./harmonizer-2`](./harmonizer-2/RELEASE_CHECKLIST.md) |

--- a/apollo-federation-types/RELEASE_CHECKLIST.md
+++ b/apollo-federation-types/RELEASE_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Release Checklist
+
+This is a list of the things that need to happen when publishing `apollo-federation-types`.
+
+## Build a Release
+
+### Changelog
+
+None of the `federation-rs` packages currently maintain changelogs as they are largely mirrors of upstream packages. You're off the hook!
+
+### Start a release PR
+
+1. Make sure you have both `npm` and `cargo` installed on your machine and in your `PATH`.
+1. Run `PUBSLUG=apollo-federation-types@v{version}` where `{version}` is the new version you're bumping to.
+1. Run `git checkout main && git stash && git pull && git checkout -b $PUBSLUG`.
+1. Update the version of `apollo-federation-types` in `Cargo.toml`
+1. Run `cargo build -p apollo-federation-types` from the root of `federation-rs`
+1. Push up a commit containing the version bumps with the message `release: $PUBSLUG`
+1. Wait for tests to pass on the PR
+1. Merge your PR to `main`
+
+### Build and tag release
+
+1. Once merged, run `git checkout main && git pull`
+1. Sync your local tags with the remote tags by running `git tag -d $(git tag) && git fetch --tags`
+1. Run `git tag -a $PUBSLUG -m $PUBSLUG`
+1. Run `git push --tags`
+1. Wait for CI to build and publish `apollo-federation-types` to crates.io.
+
+## Troubleshooting a release
+
+Mistakes happen. Most of these release steps are recoverable if you mess up.
+
+### I pushed the wrong tag
+
+Tags and releases can be removed in GitHub. First, [remove the remote tag](https://stackoverflow.com/questions/5480258/how-to-delete-a-remote-tag):
+
+```console
+git push --delete origin $PUBSLUG
+```
+
+This will turn the release into a `draft` and you can delete it from the edit page.
+
+Make sure you also delete the local tag:
+
+```console
+git tag --delete $PUBSLUG
+```

--- a/harmonizer-0/RELEASE_CHECKLIST.md
+++ b/harmonizer-0/RELEASE_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Release Checklist
+
+This is a list of the things that need to happen when publishing `harmonizer-0` and `supergraph-0` at the same time.
+
+## Build a Release
+
+### Changelog
+
+None of the `federation-rs` packages currently maintain changelogs as they are largely mirrors of upstream packages. You're off the hook!
+
+### Start a release PR
+
+1. Make sure you have both `npm` and `cargo` installed on your machine and in your `PATH`.
+1. Run `PUBSLUG=composition@v{version}` where `{version}` is the new version you're bumping to. The major version should NOT be 2, it should be 0.
+1. Run `git checkout main && git stash && git pull && git checkout -b $PUBSLUG`.
+1. Update the version of `harmonizer-0` in `Cargo.toml`
+1. Run `cargo build -p harmonizer-0` from the root of `federation-rs`
+1. Push up a commit containing the version bumps with the message `release: $PUBSLUG`
+1. Wait for tests to pass on the PR
+1. Merge your PR to `main`
+
+### Build and tag release
+
+1. Once merged, run `git checkout main && git pull`
+1. Sync your local tags with the remote tags by running `git tag -d $(git tag) && git fetch --tags`
+1. Run `git tag -a $PUBSLUG -m $PUBSLUG`
+1. Run `git push --tags`
+1. Wait for CI to build and publish `harmonizer` to crates.io and `supergraph` to `federation-rs` GitHub releases.
+
+## Troubleshooting a release
+
+Mistakes happen. Most of these release steps are recoverable if you mess up.
+
+### I pushed the wrong tag
+
+Tags and releases can be removed in GitHub. First, [remove the remote tag](https://stackoverflow.com/questions/5480258/how-to-delete-a-remote-tag):
+
+```console
+git push --delete origin $PUBSLUG
+```
+
+This will turn the release into a `draft` and you can delete it from the edit page.
+
+Make sure you also delete the local tag:
+
+```console
+git tag --delete $PUBSLUG
+```
+
+### I got an error from cargo complaining about the version of `apollo-federation-types`
+
+This likely means that the version has been bumped in `apollo-federation-types` and it hasn't been published yet. You'll need to follow the steps in that [release checklist](../apollo-federation-types/RELEASE_CHECKLIST.md) prior to publishing.

--- a/harmonizer-2/RELEASE_CHECKLIST.md
+++ b/harmonizer-2/RELEASE_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Release Checklist
+
+This is a list of the things that need to happen when publishing `harmonizer-2` and `supergraph-2` at the same time.
+
+## Build a Release
+
+### Changelog
+
+None of the `federation-rs` packages currently maintain changelogs as they are largely mirrors of upstream packages. You're off the hook!
+
+### Start a release PR
+
+1. Make sure you have both `npm` and `cargo` installed on your machine and in your `PATH`.
+1. Run `PUBSLUG=composition@v{version}` where `{version}` is the new version you're bumping to. The major version should NOT be 0, it should be 2.
+1. Run `git checkout main && git stash && git pull && git checkout -b $PUBSLUG`.
+1. Update the version of `harmonizer-2` in `Cargo.toml`
+1. Run `cargo build -p harmonizer-2` from the root of `federation-rs`
+1. Push up a commit containing the version bumps with the message `release: $PUBSLUG`
+1. Wait for tests to pass on the PR
+1. Merge your PR to `main`
+
+### Build and tag release
+
+1. Once merged, run `git checkout main && git pull`
+1. Sync your local tags with the remote tags by running `git tag -d $(git tag) && git fetch --tags`
+1. Run `git tag -a $PUBSLUG -m $PUBSLUG`
+1. Run `git push --tags`
+1. Wait for CI to build and publish `harmonizer` to crates.io and `supergraph` to `federation-rs` GitHub releases.
+
+## Troubleshooting a release
+
+Mistakes happen. Most of these release steps are recoverable if you mess up.
+
+### I pushed the wrong tag
+
+Tags and releases can be removed in GitHub. First, [remove the remote tag](https://stackoverflow.com/questions/5480258/how-to-delete-a-remote-tag):
+
+```console
+git push --delete origin $PUBSLUG
+```
+
+This will turn the release into a `draft` and you can delete it from the edit page.
+
+Make sure you also delete the local tag:
+
+```console
+git tag --delete $PUBSLUG
+```
+
+### I got an error from cargo complaining about the version of `apollo-federation-types`
+
+This likely means that the version has been bumped in `apollo-federation-types` and it hasn't been published yet. You'll need to follow the steps in that [release checklist](../apollo-federation-types/RELEASE_CHECKLIST.md) prior to publishing.

--- a/router-bridge/RELEASE_CHECKLIST.md
+++ b/router-bridge/RELEASE_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Release Checklist
+
+This is a list of the things that need to happen when publishing `router-bridge`.
+
+## Build a Release
+
+### Changelog
+
+None of the `federation-rs` packages currently maintain changelogs as they are largely mirrors of upstream packages. You're off the hook!
+
+### Start a release PR
+
+1. Make sure you have both `npm` and `cargo` installed on your machine and in your `PATH`.
+1. Run `PUBSLUG=router-bridge@v{version}` where `{version}` is the new version you're bumping to.
+1. Run `git checkout main && git stash && git pull && git checkout -b $PUBSLUG`.
+1. Update the version of `router-bridge` in `Cargo.toml`
+1. Run `cargo build -p router-bridge` from the root of `federation-rs`
+1. Push up a commit containing the version bumps with the message `release: $PUBSLUG`
+1. Wait for tests to pass on the PR
+1. Merge your PR to `main`
+
+### Build and tag release
+
+1. Once merged, run `git checkout main && git pull`
+1. Sync your local tags with the remote tags by running `git tag -d $(git tag) && git fetch --tags`
+1. Run `git tag -a $PUBSLUG -m $PUBSLUG`
+1. Run `git push --tags`
+1. Wait for CI to build and publish `router-bridge` to crates.io.
+
+## Troubleshooting a release
+
+Mistakes happen. Most of these release steps are recoverable if you mess up.
+
+### I pushed the wrong tag
+
+Tags and releases can be removed in GitHub. First, [remove the remote tag](https://stackoverflow.com/questions/5480258/how-to-delete-a-remote-tag):
+
+```console
+git push --delete origin $PUBSLUG
+```
+
+This will turn the release into a `draft` and you can delete it from the edit page.
+
+Make sure you also delete the local tag:
+
+```console
+git tag --delete $PUBSLUG
+```


### PR DESCRIPTION
fixes #38 by adding multiple release checklists in the directories where they should be, and another one at the root of the repository that links to the ones that someone would want in a given situation. 

we still need to make what the release checklists actually work by finishing #13. this PR is currently marked as a draft and should not be merged until we add a release workflow to our CircleCI config.