### PR TITLE
Api schema support

### DIFF
--- a/router-bridge/js-src/api_schema.ts
+++ b/router-bridge/js-src/api_schema.ts
@@ -1,20 +1,20 @@
 import {
-  buildSchema as gqlBuildSchema,
+  buildSchema as buildGraphqlSchema,
   ExecutionResult,
   GraphQLError,
   printSchema,
 } from "graphql";
 
-import { buildSchema } from "@apollo/federation-internals";
+import { buildSchema as buildFederatedSchema } from "@apollo/federation-internals";
 
 export function apiSchema(sdl: string): ExecutionResult<String> {
   let schema: String;
   try {
     // First go through regular schema parsing
-    gqlBuildSchema(sdl);
+    buildGraphqlSchema(sdl);
 
     // Now try to get the API schema
-    let composedSchema = buildSchema(sdl);
+    let composedSchema = buildFederatedSchema(sdl);
     let apiSchema = composedSchema.toAPISchema();
     schema = printSchema(apiSchema.toGraphQLJSSchema());
   } catch (e) {

--- a/router-bridge/js-src/api_schema.ts
+++ b/router-bridge/js-src/api_schema.ts
@@ -1,0 +1,31 @@
+import {
+  buildSchema as gqlBuildSchema,
+  ExecutionResult,
+  GraphQLError,
+  printSchema,
+} from "graphql";
+
+import { buildSchema } from "@apollo/federation-internals";
+
+export function apiSchema(sdl: string): ExecutionResult<String> {
+  let schema: String;
+  try {
+    // First go through regular schema parsing
+    gqlBuildSchema(sdl);
+
+    // Now try to get the API schema
+    let composedSchema = buildSchema(sdl);
+    let apiSchema = composedSchema.toAPISchema();
+    schema = printSchema(apiSchema.toGraphQLJSSchema());
+  } catch (e) {
+    return {
+      errors: [e],
+    };
+  }
+  if (!schema) {
+    return {
+      errors: [new GraphQLError("couldn't build api schema from SDL")],
+    };
+  }
+  return { data: schema, errors: [] };
+}

--- a/router-bridge/js-src/do_api_schema.ts
+++ b/router-bridge/js-src/do_api_schema.ts
@@ -1,0 +1,20 @@
+import type { apiSchema } from ".";
+import type { OperationResult } from "./types";
+
+/**
+ * There are several global properties that we make available in our V8 runtime
+ * and these are the types for those that we expect to use within this script.
+ * They'll be stripped in the emitting of this file as JS, of course.
+ */
+declare let bridge: { apiSchema: typeof apiSchema };
+
+declare let done: (operationResult: OperationResult) => void;
+declare let sdl: string;
+
+const result = bridge.apiSchema(sdl);
+
+if (result.errors?.length > 0) {
+  done({ Err: result.errors });
+} else {
+  done({ Ok: result.data });
+}

--- a/router-bridge/js-src/index.ts
+++ b/router-bridge/js-src/index.ts
@@ -1,2 +1,3 @@
+export { apiSchema } from "./api_schema";
 export { introspect, batchIntrospect } from "./introspection";
 export { plan } from "./plan";

--- a/router-bridge/js-src/introspection.ts
+++ b/router-bridge/js-src/introspection.ts
@@ -1,10 +1,12 @@
 import {
-  buildSchema,
+  buildSchema as gqlBuildSchema,
   ExecutionResult,
   GraphQLError,
   GraphQLSchema,
   graphqlSync,
 } from "graphql";
+
+import { buildSchema } from "@apollo/federation-internals";
 
 export function batchIntrospect(
   sdl: string,
@@ -12,7 +14,13 @@ export function batchIntrospect(
 ): ExecutionResult[] {
   let schema: GraphQLSchema;
   try {
-    schema = buildSchema(sdl);
+    // First go through regular schema parsing
+    gqlBuildSchema(sdl);
+
+    // Now try to get the API schema
+    let composedSchema = buildSchema(sdl);
+    let apiSchema = composedSchema.toAPISchema();
+    schema = apiSchema.toGraphQLJSSchema();
   } catch (e) {
     return Array(queries.length).fill({
       errors: [e],
@@ -29,7 +37,13 @@ export function batchIntrospect(
 export function introspect(sdl: string, query: string): ExecutionResult {
   let schema: GraphQLSchema;
   try {
-    schema = buildSchema(sdl);
+    // First go through regular schema parsing
+    gqlBuildSchema(sdl);
+
+    // Now try to get the API schema
+    let composedSchema = buildSchema(sdl);
+    let apiSchema = composedSchema.toAPISchema();
+    schema = apiSchema.toGraphQLJSSchema();
   } catch (e) {
     return {
       errors: [e],

--- a/router-bridge/js-src/plan.ts
+++ b/router-bridge/js-src/plan.ts
@@ -13,8 +13,9 @@ export function plan(
 ): ExecutionResult<QueryPlan> {
   try {
     const composedSchema = buildSchema(schemaString);
+    const apiSchema = composedSchema.toAPISchema();
     const operationDocument = parse(operationString);
-    const graphqlJsSchema = composedSchema.toGraphQLJSSchema();
+    const graphqlJsSchema = apiSchema.toGraphQLJSSchema();
 
     // Federation does some validation, but not all.  We need to do
     // all default validations that are provided by GraphQL.

--- a/router-bridge/src/api_schema.rs
+++ b/router-bridge/src/api_schema.rs
@@ -1,0 +1,68 @@
+/*!
+# Generate an API schema from an sdl.
+*/
+
+use crate::error::Error;
+use crate::js::Js;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use thiserror::Error;
+
+/// An error which occurred during JavaScript api schema generation.
+///
+/// The shape of this error is meant to mimick that of the error created within
+/// JavaScript, which is a [`GraphQLError`] from the [`graphql-js`] library.
+///
+/// [`graphql-js']: https://npm.im/graphql
+/// [`GraphQLError`]: https://github.com/graphql/graphql-js/blob/3869211/src/error/GraphQLError.js#L18-L75
+#[derive(Debug, Error, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ApiSchemaError {
+    /// A human-readable description of the error that prevented api schema generation.
+    pub message: Option<String>,
+}
+
+impl Display for ApiSchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message.as_deref().unwrap_or("UNKNOWN"))
+    }
+}
+
+/// The type returned when invoking `api_schema`
+pub type ApiSchemaResult = Result<String, Vec<ApiSchemaError>>;
+
+/// The `api_schema` function receives a [`string`] representing the SDL and invokes JavaScript
+/// functions to parse, convert to apiSchema and print to string.
+///
+pub fn api_schema(sdl: &str) -> Result<ApiSchemaResult, Error> {
+    Js::new()
+        .with_parameter("sdl", sdl)?
+        .execute::<ApiSchemaResult>("do_api_schema", include_str!("../js-dist/do_api_schema.js"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api_schema::{api_schema, ApiSchemaError};
+
+    #[test]
+    fn it_works() {
+        let raw_sdl = include_str!("testdata/contract_schema.graphql");
+
+        let api_schema = api_schema(raw_sdl).unwrap();
+        insta::assert_snapshot!(&api_schema.unwrap());
+    }
+
+    #[test]
+    fn invalid_sdl() {
+        let expected_error = ApiSchemaError {
+            message: Some(r#"Unknown type "Query"."#.to_string()),
+        };
+        let response = api_schema(
+            "schema {
+                query: Query
+            }",
+        )
+        .expect("an uncaught deno error occured");
+
+        assert_eq!(response.err().unwrap(), vec![expected_error]);
+    }
+}

--- a/router-bridge/src/lib.rs
+++ b/router-bridge/src/lib.rs
@@ -5,6 +5,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, future_incompatible, unreachable_pub, rust_2018_idioms)]
+pub mod api_schema;
 pub mod error;
 pub mod introspect;
 mod js;

--- a/router-bridge/src/snapshots/router_bridge__api_schema__tests__it_works.snap
+++ b/router-bridge/src/snapshots/router_bridge__api_schema__tests__it_works.snap
@@ -1,0 +1,41 @@
+---
+source: router-bridge/src/api_schema.rs
+assertion_line: 60
+expression: "&api_schema.unwrap()"
+
+---
+directive @apollo_studio_metadata(launchId: String, buildId: String, checkId: String) on SCHEMA
+
+type Mutation {
+  createProduct(name: String, upc: ID!): Product
+  createReview(body: String, id: ID!, upc: ID!): Review
+}
+
+type Product {
+  name: String
+  price: Int
+  reviews: [Review]
+  reviewsForAuthor(authorID: ID!): [Review]
+  shippingEstimate: Int
+  upc: String!
+  weight: Int
+}
+
+type Query {
+  me: User
+  topProducts(first: Int = 5): [Product]
+}
+
+type Review {
+  author: User
+  body: String
+  id: ID!
+  product: Product
+}
+
+type User {
+  id: ID!
+  name: String
+  reviews: [Review]
+  username: String
+}

--- a/router-bridge/src/testdata/contract_schema.graphql
+++ b/router-bridge/src/testdata/contract_schema.graphql
@@ -1,0 +1,64 @@
+schema @core(feature: "https://specs.apollo.dev/core/v0.1") @core(feature: "https://specs.apollo.dev/join/v0.1") @core(feature: "https://specs.apollo.dev/tag/v0.1") @apollo_studio_metadata(launchId: "2396d4fb-a1e4-457d-8da4-347479b852f1", buildId: "2396d4fb-a1e4-457d-8da4-347479b852f1", checkId: null) @core(feature: "https://specs.apollo.dev/inaccessible/v0.1") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+directive @apollo_studio_metadata(launchId: String, buildId: String, checkId: String) on SCHEMA
+
+directive @inaccessible on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts.demo.starstuff.dev/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory.demo.starstuff.dev/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products.demo.starstuff.dev/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews.demo.starstuff.dev/graphql")
+}
+
+type Mutation {
+  createProduct(name: String, upc: ID!): Product @join__field(graph: PRODUCTS)
+  createReview(body: String, id: ID!, upc: ID!): Review @join__field(graph: REVIEWS)
+}
+
+type Product @join__owner(graph: PRODUCTS) @join__type(graph: PRODUCTS, key: "upc") @join__type(graph: REVIEWS, key: "upc") @join__type(graph: INVENTORY, key: "upc") {
+  inStock: Boolean @join__field(graph: INVENTORY) @tag(name: "private") @inaccessible
+  name: String @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  upc: String! @join__field(graph: PRODUCTS)
+  weight: Int @join__field(graph: PRODUCTS)
+}
+
+type Query {
+  me: User @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__owner(graph: REVIEWS) @join__type(graph: REVIEWS, key: "id") {
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  body: String @join__field(graph: REVIEWS)
+  id: ID! @join__field(graph: REVIEWS)
+  product: Product @join__field(graph: REVIEWS)
+}
+
+type User @join__owner(graph: ACCOUNTS) @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, key: "id") {
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: String @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  username: String @join__field(graph: ACCOUNTS)
+}


### PR DESCRIPTION
This PR updates existing query planning and introspection to use API schema and and also adds a dedicated way for rust to generate the API schema.

Fixes #46 