### PR TITLE
fix: npm install instead of npm ci

### DIFF
--- a/build_harmonizer.rs
+++ b/build_harmonizer.rs
@@ -25,21 +25,34 @@ fn main() {
     create_snapshot().expect("unable to create v8 snapshot: query_runtime.snap");
 }
 
-// runs `npm ci` && `npm run build` in the current `harmonizer-x` workspace crate
+// runs `npm install` && `npm run build` in the current `harmonizer-x` workspace crate
 fn bundle_for_deno() {
     let npm = which::which("npm").expect("You must have npm installed to build this crate.");
     let current_dir = std::env::current_dir().unwrap();
 
-    println!(
-        "cargo:warning=running `npm ci` in {}",
-        &current_dir.display()
-    );
-    assert!(Command::new(&npm)
-        .current_dir(&current_dir)
-        .args(&["ci"])
-        .status()
-        .expect("Could not get status of `npm ci`")
-        .success());
+    if cfg!(debug_assertions) {
+        println!(
+            "cargo:warning=running `npm install` in {}",
+            &current_dir.display()
+        );
+        assert!(Command::new(&npm)
+            .current_dir(&current_dir)
+            .args(&["install"])
+            .status()
+            .expect("Could not get status of `npm install`")
+            .success());
+    } else {
+        println!(
+            "cargo:warning=running `npm ci` in {}",
+            &current_dir.display()
+        );
+        assert!(Command::new(&npm)
+            .current_dir(&current_dir)
+            .args(&["ci"])
+            .status()
+            .expect("Could not get status of `npm install`")
+            .success());
+    }
 
     println!(
         "cargo:warning=running `npm run format` in {}",

--- a/build_harmonizer.rs
+++ b/build_harmonizer.rs
@@ -31,6 +31,8 @@ fn bundle_for_deno() {
     let current_dir = std::env::current_dir().unwrap();
 
     if cfg!(debug_assertions) {
+        // in debug mode we want to update the package-lock.json
+        // so we run `npm install`
         println!(
             "cargo:warning=running `npm install` in {}",
             &current_dir.display()
@@ -42,6 +44,10 @@ fn bundle_for_deno() {
             .expect("Could not get status of `npm install`")
             .success());
     } else {
+        // in release mode, we're probably running in CI
+        // and want the version we publish to match
+        // the git source
+        // so we run `npm ci`.
         println!(
             "cargo:warning=running `npm ci` in {}",
             &current_dir.display()
@@ -50,7 +56,7 @@ fn bundle_for_deno() {
             .current_dir(&current_dir)
             .args(&["ci"])
             .status()
-            .expect("Could not get status of `npm install`")
+            .expect("Could not get status of `npm ci`")
             .success());
     }
 

--- a/harmonizer-2/package-lock.json
+++ b/harmonizer-2/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@apollo/harmonizer-2",
-  "version": "2.0.0-preview.4",
+  "version": "2.0.0-preview.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/harmonizer-2",
-      "version": "2.0.0-preview.4",
+      "version": "2.0.0-preview.5",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/composition": "2.0.0-preview.4"
+        "@apollo/composition": "2.0.0-preview.5"
       },
       "devDependencies": {
         "@iarna/toml": "2.2.5",
@@ -47,12 +47,12 @@
       }
     },
     "node_modules/@apollo/composition": {
-      "version": "2.0.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.0.0-preview.4.tgz",
-      "integrity": "sha512-mOB7w64LCfE9tesBuMLiCCvKw/5De7Od7S3OYm/CFata2h6rcvaVRYE5FoBo2lH6s7Jx43cy73+rDxZ4iznNfw==",
+      "version": "2.0.0-preview.5",
+      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.0.0-preview.5.tgz",
+      "integrity": "sha512-rcXldCmEt6TzdgscmuLe+7USdgJxmrcIjSiW0HyqaK23+bEUlIq07FP5bW+lFzEAf19Y6FaSrkstluGEnCdrGQ==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.0.0-preview.4",
-        "@apollo/query-graphs": "^2.0.0-preview.4"
+        "@apollo/federation-internals": "^2.0.0-preview.5",
+        "@apollo/query-graphs": "^2.0.0-preview.5"
       },
       "engines": {
         "node": ">=12.13.0 <17.0"
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.0.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.0-preview.4.tgz",
-      "integrity": "sha512-oKjcLjgViLWOD3C4DnklGBXGTbOtPWh7EKEXJzaW3IWrmKtGP8zTTbzLLdto1chawLBLlccxEitzj4oRaYBbGg==",
+      "version": "2.0.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.0-preview.7.tgz",
+      "integrity": "sha512-pANM1JiKAyxp9WOMvjG4d4RWzbX+IbwYmVh+W80PNnS6jOBAPlYO88MAZmLn+vM8yNDwPUq0XC7xbtJImvckhA==",
       "dependencies": {
         "@apollo/core-schema": "^0.2.2",
         "chalk": "^4.1.0",
@@ -89,11 +89,11 @@
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.0.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.0-preview.4.tgz",
-      "integrity": "sha512-nKOEeXchxqb/Kqp1SjR/ddFBN/9GtEIxTjTI8bEWjdCIBjU2eSKVMDboRr0RLUej4Fv9l3PBAWdQoker6eG8HQ==",
+      "version": "2.0.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.0-preview.7.tgz",
+      "integrity": "sha512-s8JcK3SYoaLZ1qxW1/nJ2zuZTm5M4SOrq4gujJ8A/vYWdSzW6cVs1WeWZ551+iBElyPH8Mggmk0h2IZ6lblNzg==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.0.0-preview.4",
+        "@apollo/federation-internals": "^2.0.0-preview.7",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       },
@@ -1969,12 +1969,12 @@
   },
   "dependencies": {
     "@apollo/composition": {
-      "version": "2.0.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.0.0-preview.4.tgz",
-      "integrity": "sha512-mOB7w64LCfE9tesBuMLiCCvKw/5De7Od7S3OYm/CFata2h6rcvaVRYE5FoBo2lH6s7Jx43cy73+rDxZ4iznNfw==",
+      "version": "2.0.0-preview.5",
+      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.0.0-preview.5.tgz",
+      "integrity": "sha512-rcXldCmEt6TzdgscmuLe+7USdgJxmrcIjSiW0HyqaK23+bEUlIq07FP5bW+lFzEAf19Y6FaSrkstluGEnCdrGQ==",
       "requires": {
-        "@apollo/federation-internals": "^2.0.0-preview.4",
-        "@apollo/query-graphs": "^2.0.0-preview.4"
+        "@apollo/federation-internals": "^2.0.0-preview.5",
+        "@apollo/query-graphs": "^2.0.0-preview.5"
       }
     },
     "@apollo/core-schema": {
@@ -1984,9 +1984,9 @@
       "requires": {}
     },
     "@apollo/federation-internals": {
-      "version": "2.0.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.0-preview.4.tgz",
-      "integrity": "sha512-oKjcLjgViLWOD3C4DnklGBXGTbOtPWh7EKEXJzaW3IWrmKtGP8zTTbzLLdto1chawLBLlccxEitzj4oRaYBbGg==",
+      "version": "2.0.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.0-preview.7.tgz",
+      "integrity": "sha512-pANM1JiKAyxp9WOMvjG4d4RWzbX+IbwYmVh+W80PNnS6jOBAPlYO88MAZmLn+vM8yNDwPUq0XC7xbtJImvckhA==",
       "requires": {
         "@apollo/core-schema": "^0.2.2",
         "chalk": "^4.1.0",
@@ -1994,11 +1994,11 @@
       }
     },
     "@apollo/query-graphs": {
-      "version": "2.0.0-preview.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.0-preview.4.tgz",
-      "integrity": "sha512-nKOEeXchxqb/Kqp1SjR/ddFBN/9GtEIxTjTI8bEWjdCIBjU2eSKVMDboRr0RLUej4Fv9l3PBAWdQoker6eG8HQ==",
+      "version": "2.0.0-preview.7",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.0-preview.7.tgz",
+      "integrity": "sha512-s8JcK3SYoaLZ1qxW1/nJ2zuZTm5M4SOrq4gujJ8A/vYWdSzW6cVs1WeWZ551+iBElyPH8Mggmk0h2IZ6lblNzg==",
       "requires": {
-        "@apollo/federation-internals": "^2.0.0-preview.4",
+        "@apollo/federation-internals": "^2.0.0-preview.7",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       }

--- a/router-bridge/build.rs
+++ b/router-bridge/build.rs
@@ -16,6 +16,8 @@ fn update_bridge() {
     let current_dir = std::env::current_dir().unwrap();
 
     if cfg!(debug_assertions) {
+        // in debug mode we want to update the package-lock.json
+        // so we run `npm install`
         println!("cargo:warning=running `npm install`");
         assert!(Command::new(&npm)
             .current_dir(&current_dir)
@@ -24,6 +26,10 @@ fn update_bridge() {
             .unwrap()
             .success());
     } else {
+        // in release mode, we're probably running in CI
+        // and want the version we publish to match
+        // the git source
+        // so we run `npm ci`.
         println!("cargo:warning=running `npm ci`");
         assert!(Command::new(&npm)
             .current_dir(&current_dir)

--- a/router-bridge/build.rs
+++ b/router-bridge/build.rs
@@ -15,13 +15,23 @@ fn update_bridge() {
     let npm = which::which("npm").unwrap();
     let current_dir = std::env::current_dir().unwrap();
 
-    println!("cargo:warning=running `npm ci`");
-    assert!(Command::new(&npm)
-        .current_dir(&current_dir)
-        .args(&["ci"])
-        .status()
-        .unwrap()
-        .success());
+    if cfg!(debug_assertions) {
+        println!("cargo:warning=running `npm install`");
+        assert!(Command::new(&npm)
+            .current_dir(&current_dir)
+            .args(&["install"])
+            .status()
+            .unwrap()
+            .success());
+    } else {
+        println!("cargo:warning=running `npm ci`");
+        assert!(Command::new(&npm)
+            .current_dir(&current_dir)
+            .args(&["ci"])
+            .status()
+            .unwrap()
+            .success());
+    }
 
     println!("cargo:warning=running `npm run fmt`");
     assert!(Command::new(&npm)


### PR DESCRIPTION
if you take a look at the diff you'll see that `package.json` is not updated and the `package-lock.json` is updated - meaning our last publishes contained incorrect versions because the lockfile was out of date.

we need to be running `npm install` instead of `npm ci` in debug mode because `npm ci` doesn't update the `package-lock.json`, and when we're running locally we want that to happen. in release mode we _don't_ want to update `package-lock.json` so that what we publish reflects what's in the lockfile.