### PR TITLE
Add sha256sums.txt as a required build artifact

### DIFF
--- a/xtask/src/packages.rs
+++ b/xtask/src/packages.rs
@@ -221,6 +221,7 @@ impl BinaryCrate {
         }
         required_artifacts.push("LICENSE".to_string());
         required_artifacts.push("sha1sums.txt".to_string());
+        required_artifacts.push("sha256sums.txt".to_string());
         required_artifacts.push("md5sums.txt".to_string());
         required_artifacts
     }
@@ -266,7 +267,7 @@ impl BinaryCrate {
                 true
             } else {
                 crate::info!(
-                    "we require {} before publishing, but it does not exist.",
+                    "Found superfluous artifact file {} when publishing. Either add it to the list of required artifact files or ensure the artifact is not created.",
                     ef
                 );
                 false


### PR DESCRIPTION
sha256sums.txt is built during the release process, but it was never added to the list of artifacts we look for during publish. Now publishing will correctly check for sha256sums.txt.