### PR TITLE
Fix target detection for macos

### DIFF
--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -67,17 +67,15 @@ impl Target {
 impl Default for Target {
     fn default() -> Self {
         if cfg!(target_os = "macos") {
-            Target::MacOS
-        } else if cfg!(target_os = "windows") {
-            Target::Windows
-        } else if cfg!(target_arch = "x86_64")
-            && cfg!(target_os = "linux")
-            && cfg!(target_env = "gnu")
-        {
-            Target::GnuLinux
-        } else {
-            Target::Other
+            return Target::MacOS;
+        } else if cfg!(target_arch = "x86_64") {
+            if cfg!(target_os = "windows") {
+                return Target::Windows;
+            } else if cfg!(target_os = "linux") && cfg!(target_env = "gnu") {
+                return Target::GnuLinux;
+            }
         }
+        Target::Other
     }
 }
 

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -66,20 +66,15 @@ impl Target {
 
 impl Default for Target {
     fn default() -> Self {
-        if cfg!(target_arch = "x86_64") {
-            if cfg!(target_os = "windows") {
-                Target::Windows
-            } else if cfg!(target_os = "linux") {
-                if cfg!(target_env = "gnu") {
-                    Target::GnuLinux
-                } else {
-                    Target::Other
-                }
-            } else if cfg!(target_os = "macos") {
-                Target::MacOS
-            } else {
-                Target::Other
-            }
+        if cfg!(target_os = "macos") {
+            Target::MacOS
+        } else if cfg!(target_os = "windows") {
+            Target::Windows
+        } else if cfg!(target_arch = "x86_64")
+            && cfg!(target_os = "linux")
+            && cfg!(target_env = "gnu")
+        {
+            Target::GnuLinux
         } else {
             Target::Other
         }


### PR DESCRIPTION
Fix target detection when running `cargo xtask` on macos. This also changes target detection slightly for windows, in that we won't care about the target architecture.

Fixes #83