### PR TITLE
feat: allows pinning versions in SupergraphConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_fs",
  "camino",

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation-types"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 description = """

--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -248,7 +248,7 @@ subgraphs:
         let config = SupergraphConfig::new_from_yaml(raw_good_yaml).unwrap();
         assert_eq!(
             config.federation_version,
-            FederationVersion::ExactFedTwo(Version::parse("0.36.0").unwrap())
+            FederationVersion::ExactFedOne(Version::parse("0.36.0").unwrap())
         );
     }
 

--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -1,5 +1,6 @@
 use crate::config::ConfigError;
 
+use semver::Version;
 use serde::{Deserialize, Serialize};
 
 use std::{
@@ -7,23 +8,58 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum FederationVersion {
-    FedOne,
-    FedTwo,
+    LatestFedOne,
+    LatestFedTwo,
+    ExactFedOne(Version),
+    ExactFedTwo(Version),
+}
+
+impl FederationVersion {
+    pub fn get_major_version(&self) -> u64 {
+        match self {
+            Self::LatestFedOne | Self::ExactFedOne(_) => 0,
+            Self::LatestFedTwo | Self::ExactFedTwo(_) => 2,
+        }
+    }
+
+    pub fn get_exact(&self) -> Option<&Version> {
+        match self {
+            Self::ExactFedOne(version) | Self::ExactFedTwo(version) => Some(version),
+            _ => None,
+        }
+    }
+
+    pub fn is_fed_one(&self) -> bool {
+        matches!(self, Self::LatestFedOne) || matches!(self, Self::ExactFedOne(_))
+    }
+
+    pub fn is_fed_two(&self) -> bool {
+        matches!(self, Self::LatestFedTwo) || matches!(self, Self::ExactFedTwo(_))
+    }
+
+    pub fn get_tarball_version(&self) -> String {
+        match self {
+            Self::LatestFedOne => "latest-0".to_string(),
+            Self::LatestFedTwo => "latest-2".to_string(),
+            Self::ExactFedOne(v) | Self::ExactFedTwo(v) => format!("v{}", v),
+        }
+    }
 }
 
 impl Default for FederationVersion {
     fn default() -> Self {
-        FederationVersion::FedTwo
+        FederationVersion::LatestFedOne
     }
 }
 
 impl Display for FederationVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let result = match self {
-            Self::FedOne => "0",
-            Self::FedTwo => "2",
+            Self::LatestFedOne => "0".to_string(),
+            Self::LatestFedTwo => "2".to_string(),
+            Self::ExactFedOne(version) | Self::ExactFedTwo(version) => format!("={}", version),
         };
         write!(f, "{}", result)
     }
@@ -33,12 +69,35 @@ impl FromStr for FederationVersion {
     type Err = ConfigError;
 
     fn from_str(input: &str) -> std::result::Result<Self, Self::Err> {
-        match input {
-            "0" | "1" => Ok(Self::FedOne),
-            "2" => Ok(Self::FedTwo),
-            _ => Err(ConfigError::InvalidConfiguration {
-                message: format!("Specified version `{}` is not supported", input),
-            }),
+        let invalid_version = ConfigError::InvalidConfiguration {
+            message: format!("Specified version `{}` is not supported. You can either specify '1', '2', or a fully qualified version prefixed with an '=', like: =2.0.0", input),
+        };
+        if input.len() > 1 && (input.starts_with("=") || input.starts_with("v")) {
+            if let Ok(version) = input[1..].parse::<Version>() {
+                if version.major == 0 {
+                    if version.minor >= 36 {
+                        Ok(Self::ExactFedOne(version))
+                    } else {
+                        Err(ConfigError::InvalidConfiguration { message: format!("Specified version `{}` is not supported. The earliest version you can specify for federation 1 is '=0.36.0'", input) })
+                    }
+                } else if version.major == 2 {
+                    if version >= "2.0.0-preview.9".parse::<Version>().unwrap() {
+                        Ok(Self::ExactFedTwo(version))
+                    } else {
+                        Err(ConfigError::InvalidConfiguration { message: format!("Specified version `{}` is not supported. The earliest version you can specify for federation 2 is '=2.0.0-preview.9'", input) })
+                    }
+                } else {
+                    Err(invalid_version)
+                }
+            } else {
+                Err(invalid_version)
+            }
+        } else {
+            match input {
+                "0" | "1" | "latest-0" | "latest-1" => Ok(Self::LatestFedOne),
+                "2" | "latest-2" => Ok(Self::LatestFedTwo),
+                _ => Err(invalid_version),
+            }
         }
     }
 }

--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -72,7 +72,7 @@ impl FromStr for FederationVersion {
         let invalid_version = ConfigError::InvalidConfiguration {
             message: format!("Specified version `{}` is not supported. You can either specify '1', '2', or a fully qualified version prefixed with an '=', like: =2.0.0", input),
         };
-        if input.len() > 1 && (input.starts_with("=") || input.starts_with("v")) {
+        if input.len() > 1 && (input.starts_with('=') || input.starts_with('v')) {
             if let Ok(version) = input[1..].parse::<Version>() {
                 if version.major == 0 {
                     if version.minor >= 36 {

--- a/federation-1/Cargo.lock
+++ b/federation-1/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-1/harmonizer/Cargo.toml
+++ b/federation-1/harmonizer/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.3", path = "../../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.4", path = "../../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.118.0"

--- a/federation-1/supergraph/src/command/compose.rs
+++ b/federation-1/supergraph/src/command/compose.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 
 use apollo_federation_types::{
     build::BuildResult,
-    config::{ConfigError, FederationVersion, SupergraphConfig},
+    config::{ConfigError, SupergraphConfig},
 };
 use harmonizer::harmonize;
 
@@ -32,7 +32,7 @@ impl Compose {
     fn do_compose(&self) -> BuildResult {
         let supergraph_config = SupergraphConfig::new_from_yaml_file(&self.config_file)?;
         let federation_version = supergraph_config.get_federation_version();
-        if !matches!(federation_version, FederationVersion::FedOne) {
+        if !matches!(federation_version.get_major_version(), 0 | 1) {
             return Err(ConfigError::InvalidConfiguration {message: format!("It looks like '{}' resolved to 'federation_version: {}', which doesn't match the current supergraph binary.", &self.config_file, federation_version )}.into());
         }
         let subgraph_definitions = supergraph_config.get_subgraph_definitions()?;

--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-2/harmonizer/Cargo.toml
+++ b/federation-2/harmonizer/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.3", path = "../../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.4", path = "../../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.118.0"

--- a/federation-2/supergraph/src/command/compose.rs
+++ b/federation-2/supergraph/src/command/compose.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 
 use apollo_federation_types::{
     build::BuildResult,
-    config::{ConfigError, FederationVersion, SupergraphConfig},
+    config::{ConfigError, SupergraphConfig},
 };
 use harmonizer::harmonize;
 
@@ -32,7 +32,7 @@ impl Compose {
     fn do_compose(&self) -> BuildResult {
         let supergraph_config = SupergraphConfig::new_from_yaml_file(&self.config_file)?;
         let federation_version = supergraph_config.get_federation_version();
-        if !matches!(federation_version, FederationVersion::FedTwo) {
+        if !matches!(federation_version.get_major_version(), 2) {
             return Err(ConfigError::InvalidConfiguration {message: format!("It looks like '{}' resolved to 'federation_version: {}', which doesn't match the current supergraph binary.", &self.config_file, federation_version )}.into());
         }
         let subgraph_definitions = supergraph_config.get_subgraph_definitions()?;


### PR DESCRIPTION
now instead of just `federation_version: 1` or `federation_version: 2`, you can specify `federation_version: =2.0.0` and rover will attempt to use that specific version. also the default (if the version is left out) is now 1, so folks using federation 1 won't have their CI pipelines busted overnight.