### PR TITLE
fix: QueryPlanner Request race

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "deno_core 0.124.0",
+ "futures",
  "insta",
  "serde",
  "serde_json",
@@ -888,6 +889,8 @@ dependencies = [
  "tokio",
  "tower",
  "tower-service",
+ "tracing",
+ "uuid",
  "which",
 ]
 
@@ -1265,14 +1268,26 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
 dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1327,6 +1342,16 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
  "serde",
 ]
 

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -22,8 +22,11 @@ thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["full"] }
 tower = { version = "0.4.12", features = ["full"] }
 tower-service = "0.3.1"
+tracing = "0.1.33"
+uuid = { version = "0.8.2", features = ["v4", "serde"] }
 
 [dev-dependencies]
+futures = "0.3.21"
 insta = "1.8.0"
 
 [build-dependencies]

--- a/federation-2/router-bridge/js-src/plan_worker.ts
+++ b/federation-2/router-bridge/js-src/plan_worker.ts
@@ -62,7 +62,7 @@ const updateQueryPlanner = (schema: string): WorkerResult => {
     const errors = errorArray.map((err) => {
       // We can't import GraphqlError,
       // which would have been less hacky
-      if (!!err.extensions) {
+      if (err?.extensions !== null && err?.extensions !== undefined) {
         return err;
       }
 

--- a/federation-2/router-bridge/js-src/plan_worker.ts
+++ b/federation-2/router-bridge/js-src/plan_worker.ts
@@ -23,6 +23,15 @@ interface Exit {
   kind: PlannerEventKind.Exit;
 }
 type PlannerEvent = UpdateSchemaEvent | PlanEvent | Exit;
+type PlannerEventWithId = {
+  id: string;
+  payload: PlannerEvent;
+};
+
+type WorkerResultWithId = {
+  id?: string;
+  payload: WorkerResult;
+};
 type WorkerResult =
   // Plan result
   ExecutionResult<QueryPlan> | FatalError;
@@ -31,9 +40,9 @@ type FatalError = {
   errors: Error[];
 };
 
-const send = async (payload: WorkerResult): Promise<void> =>
+const send = async (payload: WorkerResultWithId): Promise<void> =>
   await Deno.core.opAsync("send", payload);
-const receive = async (): Promise<PlannerEvent> =>
+const receive = async (): Promise<PlannerEventWithId> =>
   await Deno.core.opAsync("receive");
 
 let planner: BridgeQueryPlanner;
@@ -43,8 +52,28 @@ const updateQueryPlanner = (schema: string): WorkerResult => {
     planner = new bridge.BridgeQueryPlanner(schema);
     // This will be interpreted as a correct Update
     return { data: { kind: "QueryPlan", node: null } };
-  } catch (e) {
-    const errors = Array.isArray(e) ? e : [e];
+  } catch (err) {
+    // The error that has been thrown needs to be sent back
+    // to the rust runtime. In order to do so, it will be serialized.
+    // The code below will allow us to build an object that is JSON serializable,
+    // yet contains all of the information we need
+
+    const errorArray = Array.isArray(err) ? err : [err];
+    const errors = errorArray.map((err) => {
+      // We can't import GraphqlError,
+      // which would have been less hacky
+      if (!!err.extensions) {
+        return err;
+      }
+
+      const { name, message, stack } = err;
+      return {
+        name,
+        message,
+        stack,
+      };
+    });
+
     return { errors };
   }
 };
@@ -52,25 +81,30 @@ const updateQueryPlanner = (schema: string): WorkerResult => {
 async function run() {
   while (true) {
     try {
-      const event = await receive();
-      switch (event?.kind) {
-        case PlannerEventKind.UpdateSchema:
-          const updateResult = updateQueryPlanner(event.schema);
-          await send(updateResult);
-          break;
-        case PlannerEventKind.Plan:
-          const result = planner.plan(event.query, event.operationName);
-          await send(result);
-          break;
-        case PlannerEventKind.Exit:
-          return;
-        default:
-          print(`unknown message received: ${JSON.stringify(event)}\n`);
-          break;
+      const { id, payload: event } = await receive();
+      try {
+        switch (event?.kind) {
+          case PlannerEventKind.UpdateSchema:
+            const updateResult = updateQueryPlanner(event.schema);
+            await send({ id, payload: updateResult });
+            break;
+          case PlannerEventKind.Plan:
+            const planResult = planner.plan(event.query, event.operationName);
+            await send({ id, payload: planResult });
+            break;
+          case PlannerEventKind.Exit:
+            return;
+          default:
+            print(`unknown message received: ${JSON.stringify(event)}\n`);
+            break;
+        }
+      } catch (e) {
+        print(`an error happened in the worker runtime ${e}\n`);
+        await send({ id, payload: { errors: [e] } });
       }
     } catch (e) {
-      print(`received error ${e}\n`);
-      await send({ errors: [e] });
+      print(`an unknown error occured ${e}\n`);
+      await send({ payload: { errors: [e] } });
     }
   }
 }

--- a/federation-2/router-bridge/package-lock.json
+++ b/federation-2/router-bridge/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0-alpha.6",
       "license": "SEE LICENSE IN ./LICENSE",
       "dependencies": {
-        "@apollo/query-planner": "2.0.0",
+        "@apollo/query-planner": "2.0.1",
         "fast-text-encoding": "1.0.3",
         "graphql": "16.3.0",
         "whatwg-url": "11.0.0"
@@ -31,22 +31,25 @@
       }
     },
     "node_modules/@apollo/core-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@apollo/core-schema/-/core-schema-0.2.3.tgz",
-      "integrity": "sha512-0MXK/rlo2Es6qp4nb5lkMcN8jz3AaXm7TiPENO9Cyyy8kIC6rTKKpHCd1yv/E5aDEIFFq44LJcL+WrLONSy7+g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@apollo/core-schema/-/core-schema-0.3.0.tgz",
+      "integrity": "sha512-v+Ys6+W1pDQu+XwP++tI5y4oZdzKrEuVXwsEenOmg2FO/3/G08C+qMhQ9YQ9Ug34rvQGQtgbIDssHEVk4YZS7g==",
+      "dependencies": {
+        "@protoplasm/recall": "^0.2"
+      },
       "engines": {
-        "node": ">=12.13.0 <18.0"
+        "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
+        "graphql": "^15 || ^16"
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.0.tgz",
-      "integrity": "sha512-wEQlxG0jBZXXNAP+C/UdPoZE90R6IuQQmw9MP5FWWhsPmpyeiCz3hLp+XlW+/Ptlz3yL59hx3h45I8gOkGuvFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.1.tgz",
+      "integrity": "sha512-as2lL0tChwQx3PgBKQ8hELal2paBFsbucXSba+Gi84ZP1wGtYtl5kJmE7DVImsC+/CAVjEFWM7aWQGJg6Im8Ow==",
       "dependencies": {
-        "@apollo/core-schema": "~0.2.3",
+        "@apollo/core-schema": "~0.3.0",
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
       },
@@ -58,11 +61,11 @@
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.0.tgz",
-      "integrity": "sha512-WSn2knViHKkc9MqpRRFCEGdtQ+mmn74rFdCwMDWBZ3dMnlp7v0B42r3QMUCM2KQEEGCjg/LbMSEuU31i25mRRw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.1.tgz",
+      "integrity": "sha512-jZ0Ljbzfn99XKzmH8QparOiv78xOSbJ3IzccBsPIwz7/QgcBuy82vvTTIoAGApDtPoqivP/rGinVN6ocigtHMQ==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.0.0",
+        "@apollo/federation-internals": "^2.0.1",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       },
@@ -74,12 +77,12 @@
       }
     },
     "node_modules/@apollo/query-planner": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.0.0.tgz",
-      "integrity": "sha512-I0B3BSViT/lLaWuMQxSIkp4lobF/Pyy7Sz0wlNsUxCiOJcRJfJuTbGQVzj6FBz0x25BDTElF55vKVycCmBMNsg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.0.1.tgz",
+      "integrity": "sha512-4a6mmPGd6PrKCUSBWaSoYks6hTZ1nWEi1mlBCLHVKCseBiQyj2/eOp7UoIe/0737HMRyQh/LCBPGgMPTEsPzHQ==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.0.0",
-        "@apollo/query-graphs": "^2.0.0",
+        "@apollo/federation-internals": "^2.0.1",
+        "@apollo/query-graphs": "^2.0.1",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^27.0.0"
@@ -186,6 +189,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@protoplasm/recall": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@protoplasm/recall/-/recall-0.2.2.tgz",
+      "integrity": "sha512-grQIYNd3UsFjHXL1g5Qw5MdUNAddEcD1KfqiO6WeMOQHgIgECXo7r4jfcXGIh37q17HoGQgq/G4guMGkzQ+UOA==",
+      "engines": {
+        "node": ">=12.13.0"
       }
     },
     "node_modules/@types/minimist": {
@@ -880,6 +891,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -1721,12 +1740,13 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2089,38 +2109,40 @@
   },
   "dependencies": {
     "@apollo/core-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@apollo/core-schema/-/core-schema-0.2.3.tgz",
-      "integrity": "sha512-0MXK/rlo2Es6qp4nb5lkMcN8jz3AaXm7TiPENO9Cyyy8kIC6rTKKpHCd1yv/E5aDEIFFq44LJcL+WrLONSy7+g==",
-      "requires": {}
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@apollo/core-schema/-/core-schema-0.3.0.tgz",
+      "integrity": "sha512-v+Ys6+W1pDQu+XwP++tI5y4oZdzKrEuVXwsEenOmg2FO/3/G08C+qMhQ9YQ9Ug34rvQGQtgbIDssHEVk4YZS7g==",
+      "requires": {
+        "@protoplasm/recall": "^0.2"
+      }
     },
     "@apollo/federation-internals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.0.tgz",
-      "integrity": "sha512-wEQlxG0jBZXXNAP+C/UdPoZE90R6IuQQmw9MP5FWWhsPmpyeiCz3hLp+XlW+/Ptlz3yL59hx3h45I8gOkGuvFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.0.1.tgz",
+      "integrity": "sha512-as2lL0tChwQx3PgBKQ8hELal2paBFsbucXSba+Gi84ZP1wGtYtl5kJmE7DVImsC+/CAVjEFWM7aWQGJg6Im8Ow==",
       "requires": {
-        "@apollo/core-schema": "~0.2.3",
+        "@apollo/core-schema": "~0.3.0",
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
       }
     },
     "@apollo/query-graphs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.0.tgz",
-      "integrity": "sha512-WSn2knViHKkc9MqpRRFCEGdtQ+mmn74rFdCwMDWBZ3dMnlp7v0B42r3QMUCM2KQEEGCjg/LbMSEuU31i25mRRw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.0.1.tgz",
+      "integrity": "sha512-jZ0Ljbzfn99XKzmH8QparOiv78xOSbJ3IzccBsPIwz7/QgcBuy82vvTTIoAGApDtPoqivP/rGinVN6ocigtHMQ==",
       "requires": {
-        "@apollo/federation-internals": "^2.0.0",
+        "@apollo/federation-internals": "^2.0.1",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       }
     },
     "@apollo/query-planner": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.0.0.tgz",
-      "integrity": "sha512-I0B3BSViT/lLaWuMQxSIkp4lobF/Pyy7Sz0wlNsUxCiOJcRJfJuTbGQVzj6FBz0x25BDTElF55vKVycCmBMNsg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.0.1.tgz",
+      "integrity": "sha512-4a6mmPGd6PrKCUSBWaSoYks6hTZ1nWEi1mlBCLHVKCseBiQyj2/eOp7UoIe/0737HMRyQh/LCBPGgMPTEsPzHQ==",
       "requires": {
-        "@apollo/federation-internals": "^2.0.0",
-        "@apollo/query-graphs": "^2.0.0",
+        "@apollo/federation-internals": "^2.0.1",
+        "@apollo/query-graphs": "^2.0.1",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^27.0.0"
@@ -2203,6 +2225,11 @@
           }
         }
       }
+    },
+    "@protoplasm/recall": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@protoplasm/recall/-/recall-0.2.2.tgz",
+      "integrity": "sha512-grQIYNd3UsFjHXL1g5Qw5MdUNAddEcD1KfqiO6WeMOQHgIgECXo7r4jfcXGIh37q17HoGQgq/G4guMGkzQ+UOA=="
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -2614,6 +2641,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functions-have-names": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -3163,12 +3195,13 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "safe-buffer": {

--- a/federation-2/router-bridge/package.json
+++ b/federation-2/router-bridge/package.json
@@ -27,7 +27,7 @@
     "npm": ">=7 <9"
   },
   "dependencies": {
-    "@apollo/query-planner": "2.0.0",
+    "@apollo/query-planner": "2.0.1",
     "fast-text-encoding": "1.0.3",
     "graphql": "16.3.0",
     "whatwg-url": "11.0.0"

--- a/federation-2/router-bridge/src/error.rs
+++ b/federation-2/router-bridge/src/error.rs
@@ -15,14 +15,25 @@ pub enum Error {
     /// This contains the script invocation error message.
     #[error("the deno runtime raised an error: `{0}`")]
     DenoRuntime(String),
-    /// An uncaught error was raised when trying to serialize a parameter before invoking a custom script.
+    /// An uncaught error was raised when trying to serialize a parameter before sending it to the javascript worker.
     ///
-    /// This contains the serialization error message, and the parameter name.
+    /// This contains the serialization error message, and the payload name.
     #[error("couldn't serialize parameter `{name}`: `{message}`.")]
     ParameterSerialization {
         /// The underlying serialization error.
         message: String,
         /// The name of the parameter we tried to serialize.
         name: String,
+    },
+
+    /// An uncaught error was raised when trying to deserialize a payload.
+    ///
+    /// This contains the deserialization error message, and the payload.
+    #[error("couldn't deserialize payload `{id}`: `{message}`.")]
+    ParameterDeserialization {
+        /// The underlying serialization error.
+        message: String,
+        /// The deno response id we tried to deserialize.
+        id: String,
     },
 }

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -143,7 +143,7 @@ pub struct PlannerSetupError {
     pub message: Option<String>,
     /// The error kind
     pub name: Option<String>,
-    /// A stqcktrace if applicable
+    /// A stacktrace if applicable
     pub stack: Option<String>,
 }
 

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -5,6 +5,7 @@
 use crate::worker::JsWorker;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
+use std::marker::PhantomData;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -41,26 +42,6 @@ pub struct OperationalContext {
     pub operation_name: String,
 }
 
-#[derive(Debug, Error, Serialize, Deserialize, PartialEq)]
-/// Container for planning errors
-pub struct BridgeErrors {
-    /// The contained errors
-    pub errors: Vec<BridgeError>,
-}
-
-impl Display for BridgeErrors {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "Planning errors: {}",
-            self.errors
-                .iter()
-                .map(|e| e.to_string())
-                .collect::<Vec<String>>()
-                .join(", ")
-        ))
-    }
-}
-
 /// An error which occurred during JavaScript planning.
 ///
 /// The shape of this error is meant to mimic that of the error created within
@@ -69,12 +50,12 @@ impl Display for BridgeErrors {
 /// [`graphql-js`]: https://npm.im/graphql
 /// [`GraphQLError`]: https://github.com/graphql/graphql-js/blob/3869211/src/error/GraphQLError.js#L18-L75
 #[derive(Debug, Error, Serialize, Deserialize, PartialEq)]
-pub struct BridgeError {
+pub struct PlanError {
     /// A human-readable description of the error that prevented planning.
     pub message: Option<String>,
-    /// [`BridgeErrorExtensions`]
+    /// [`PlanErrorExtensions`]
     #[serde(deserialize_with = "none_only_if_value_is_null_or_empty_object")]
-    pub extensions: Option<BridgeErrorExtensions>,
+    pub extensions: Option<PlanErrorExtensions>,
 }
 
 /// `none_only_if_value_is_null_or_empty_object`
@@ -116,7 +97,7 @@ where
     }
 }
 
-impl Display for BridgeError {
+impl Display for PlanError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(msg) = &self.message {
             f.write_fmt(format_args!("{code}: {msg}", code = self.code(), msg = msg))
@@ -128,13 +109,13 @@ impl Display for BridgeError {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 /// Error codes
-pub struct BridgeErrorExtensions {
+pub struct PlanErrorExtensions {
     /// The error code
     pub code: String,
 }
 
 /// An error that was received during planning within JavaScript.
-impl BridgeError {
+impl PlanError {
     /// Retrieve the error code from an error received during planning.
     pub fn code(&self) -> &str {
         match self.extensions {
@@ -148,24 +129,44 @@ impl BridgeError {
 
 #[derive(Deserialize, Debug)]
 /// The result of a router bridge invocation
-pub struct BridgeResult<T> {
+pub struct BridgeSetupResult<T> {
+    /// The data if setup happened successfully
+    pub data: Option<T>,
+    /// The errors if the query failed
+    pub errors: Option<Vec<PlannerSetupError>>,
+}
+
+/// We couldn't instantiate a query planner with the given schema
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct PlannerSetupError {
+    /// The error message
+    pub message: Option<String>,
+    /// The error kind
+    pub name: Option<String>,
+    /// A stqcktrace if applicable
+    pub stack: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+/// The result of a router bridge invocation
+pub struct PlanResult<T> {
     /// The data if the query was successfully run
     pub data: Option<T>,
     /// The errors if the query failed
-    pub errors: Option<Vec<BridgeError>>,
+    pub errors: Option<Vec<PlanError>>,
 }
 
-impl<T> BridgeResult<T>
+impl<T> PlanResult<T>
 where
     T: DeserializeOwned + Send + Debug + 'static,
 {
     /// Turn a BridgeResult into an actual Result
-    pub fn into_result(self) -> Result<T, Vec<BridgeError>> {
+    pub fn into_result(self) -> Result<T, Vec<PlanError>> {
         if let Some(data) = self.data {
             Ok(data)
         } else {
             Err(self.errors.unwrap_or_else(|| {
-                vec![BridgeError {
+                vec![PlanError {
                     message: Some("an unknown error occured".to_string()),
                     extensions: None,
                 }]
@@ -180,7 +181,8 @@ pub struct Planner<T>
 where
     T: DeserializeOwned + Send + Debug + 'static,
 {
-    worker: Arc<JsWorker<PlanCmd, BridgeResult<T>>>,
+    worker: Arc<JsWorker>,
+    t: PhantomData<T>,
 }
 
 impl<T> Debug for Planner<T>
@@ -197,16 +199,18 @@ where
     T: DeserializeOwned + Send + Debug + 'static,
 {
     /// Instantiate a `Planner` from a schema string
-    pub async fn new(schema: String) -> Result<Self, Vec<BridgeError>> {
-        let worker =
-            JsWorker::<PlanCmd, BridgeResult<T>>::new(include_str!("../js-dist/plan_worker.js"));
+    pub async fn new(schema: String) -> Result<Self, Vec<PlannerSetupError>> {
+        let worker = JsWorker::new(include_str!("../js-dist/plan_worker.js"));
         let worker_is_set_up = worker
-            .request(PlanCmd::UpdateSchema { schema })
+            .request::<PlanCmd, BridgeSetupResult<serde_json::Value>>(PlanCmd::UpdateSchema {
+                schema,
+            })
             .await
             .map_err(|e| {
-                vec![BridgeError {
+                vec![PlannerSetupError {
+                    name: Some("planner setup error".to_string()),
                     message: Some(e.to_string()),
-                    extensions: None,
+                    stack: None,
                 }]
             });
 
@@ -217,20 +221,25 @@ where
         // before we drop the worker
         match worker_is_set_up {
             Err(setup_error) => {
-                let _ = worker.request(PlanCmd::Exit).await;
+                let _ = worker
+                    .request::<PlanCmd, serde_json::Value>(PlanCmd::Exit)
+                    .await;
                 return Err(setup_error);
             }
             Ok(setup) => {
-                if let Some(errors) = setup.errors {
-                    let _ = worker.request(PlanCmd::Exit).await;
-                    return Err(errors);
+                if let Some(error) = setup.errors {
+                    let _ = worker.send(PlanCmd::Exit).await;
+                    return Err(error);
                 }
             }
         }
 
         let worker = Arc::new(worker);
 
-        Ok(Self { worker })
+        Ok(Self {
+            worker,
+            t: Default::default(),
+        })
     }
 
     /// Plan a query against an instantiated query planner
@@ -238,7 +247,7 @@ where
         &self,
         query: String,
         operation_name: Option<String>,
-    ) -> Result<BridgeResult<T>, crate::error::Error> {
+    ) -> Result<PlanResult<T>, crate::error::Error> {
         self.worker
             .request(PlanCmd::Plan {
                 query,
@@ -283,8 +292,10 @@ enum PlanCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::stream::{self, StreamExt};
 
     const QUERY: &str = include_str!("testdata/query.graphql");
+    const QUERY2: &str = include_str!("testdata/query2.graphql");
     const SCHEMA: &str = include_str!("testdata/schema.graphql");
 
     #[tokio::test]
@@ -312,7 +323,7 @@ mod tests {
     // expect to every show up in Federation's query planner validation.
     // This one is for the NoFragmentCyclesRule in graphql/validate
     async fn invalid_graphql_validation_1_is_caught() {
-        let errors= vec![BridgeError {
+        let errors= vec![PlanError {
                 message: Some("Cannot spread fragment \"thatUserFragment1\" within itself via \"thatUserFragment2\".".to_string()),
                 extensions: None,
             }];
@@ -345,7 +356,7 @@ mod tests {
     // expect to every show up in Federation's query planner validation.
     // This one is for the ScalarLeafsRule in graphql/validate
     async fn invalid_graphql_validation_2_is_caught() {
-        let errors = vec![BridgeError {
+        let errors = vec![PlanError {
             message: Some(
                 "Field \"id\" must not have a selection since type \"ID!\" has no subfields."
                     .to_string(),
@@ -371,7 +382,7 @@ mod tests {
     // expect to every show up in Federation's query planner validation.
     // This one is for NoUnusedFragmentsRule in graphql/validate
     async fn invalid_graphql_validation_3_is_caught() {
-        let errors = vec![BridgeError {
+        let errors = vec![PlanError {
             message: Some("Fragment \"UnusedTestFragment\" is never used.".to_string()),
             extensions: None,
         }];
@@ -387,7 +398,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_federation_validation_is_caught() {
-        let errors = vec![BridgeError {
+        let errors = vec![PlanError {
             message: Some(
                 "Must provide operation name if query contains multiple operations.".to_string(),
             ),
@@ -404,18 +415,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_deserialization_doesnt_panic() {
-        let planner = Planner::<serde_json::Number>::new(SCHEMA.to_string()).await;
-
-        dbg!(&planner);
-        assert!(planner.is_err());
-    }
-
-    #[tokio::test]
     async fn invalid_schema_is_caught() {
-        let expected_errors = vec![BridgeError {
+        let expected_errors = vec![PlannerSetupError {
+            name: None,
             message: Some("Syntax Error: Unexpected Name \"Garbage\".".to_string()),
-            extensions: None,
+            stack: None,
         }];
 
         let actual_error = Planner::<serde_json::Value>::new("Garbage".to_string())
@@ -427,7 +431,7 @@ mod tests {
 
     #[tokio::test]
     async fn syntactically_incorrect_query_is_caught() {
-        let errors = vec![BridgeError {
+        let errors = vec![PlanError {
             message: Some("Syntax Error: Unexpected Name \"Garbage\".".to_string()),
             extensions: None,
         }];
@@ -439,7 +443,7 @@ mod tests {
     async fn query_missing_subfields() {
         let expected_error_message = r#"Field "reviews" of type "[Review]" must have a selection of subfields. Did you mean "reviews { ... }"?"#;
 
-        let errors = vec![BridgeError {
+        let errors = vec![PlanError {
             message: Some(expected_error_message.to_string()),
             extensions: None,
         }];
@@ -456,7 +460,7 @@ mod tests {
     #[tokio::test]
     async fn query_field_that_doesnt_exist() {
         let expected_error_message = r#"Cannot query field "thisDoesntExist" on type "Query"."#;
-        let errors = vec![BridgeError {
+        let errors = vec![PlanError {
             message: Some(expected_error_message.to_string()),
             extensions: None,
         }];
@@ -471,7 +475,7 @@ mod tests {
     }
 
     async fn assert_errors(
-        expected_errors: Vec<BridgeError>,
+        expected_errors: Vec<PlanError>,
         query: String,
         operation_name: Option<String>,
     ) {
@@ -483,11 +487,53 @@ mod tests {
 
         assert_eq!(expected_errors, actual.errors.unwrap());
     }
+
+    #[tokio::test]
+    async fn it_doesnt_race() {
+        let planner = Planner::<serde_json::Value>::new(SCHEMA.to_string())
+            .await
+            .unwrap();
+
+        let query_1_response = planner
+            .plan(QUERY.to_string(), None)
+            .await
+            .unwrap()
+            .data
+            .unwrap();
+
+        let query_2_response = planner
+            .plan(QUERY2.to_string(), None)
+            .await
+            .unwrap()
+            .data
+            .unwrap();
+
+        let all_futures = stream::iter((0..1000).map(|i| {
+            let (query, fut) = if i % 2 == 0 {
+                (QUERY, planner.plan(QUERY.to_string(), None))
+            } else {
+                (QUERY2, planner.plan(QUERY2.to_string(), None))
+            };
+
+            async move { (query, fut.await.unwrap()) }
+        }));
+
+        all_futures
+            .for_each_concurrent(None, |fut| async {
+                let (query, plan_result) = fut.await;
+                if query == QUERY {
+                    assert_eq!(query_1_response, plan_result.data.unwrap());
+                } else {
+                    assert_eq!(query_2_response, plan_result.data.unwrap());
+                }
+            })
+            .await;
+    }
 }
 
 #[cfg(test)]
 mod planning_error {
-    use crate::planner::{BridgeError, BridgeErrorExtensions};
+    use crate::planner::{PlanError, PlanErrorExtensions};
 
     #[test]
     #[should_panic(
@@ -495,7 +541,7 @@ mod planning_error {
     )]
     fn deserialize_empty_planning_error() {
         let raw = "{}";
-        serde_json::from_str::<BridgeError>(raw).unwrap();
+        serde_json::from_str::<PlanError>(raw).unwrap();
     }
 
     #[test]
@@ -504,7 +550,7 @@ mod planning_error {
     )]
     fn deserialize_planning_error_missing_extension() {
         let raw = r#"{ "message": "something terrible happened" }"#;
-        serde_json::from_str::<BridgeError>(raw).unwrap();
+        serde_json::from_str::<PlanError>(raw).unwrap();
     }
 
     #[test]
@@ -516,9 +562,9 @@ mod planning_error {
             }
         }"#;
 
-        let expected = BridgeError {
+        let expected = PlanError {
             message: Some("something terrible happened".to_string()),
-            extensions: Some(BridgeErrorExtensions {
+            extensions: Some(PlanErrorExtensions {
                 code: "E_TEST_CASE".to_string(),
             }),
         };
@@ -531,7 +577,7 @@ mod planning_error {
         let raw = r#"{
             "extensions": {}
         }"#;
-        let expected = BridgeError {
+        let expected = PlanError {
             message: None,
             extensions: None,
         };
@@ -544,7 +590,7 @@ mod planning_error {
         let raw = r#"{
             "extensions": null
         }"#;
-        let expected = BridgeError {
+        let expected = PlanError {
             message: None,
             extensions: None,
         };

--- a/federation-2/router-bridge/src/testdata/query2.graphql
+++ b/federation-2/router-bridge/src/testdata/query2.graphql
@@ -1,0 +1,7 @@
+query {
+  me {
+    name {
+      last
+    }
+  }
+}


### PR DESCRIPTION
 fix: QueryPlanner race

This commit fixes a Race that would happen when racing queries against the planner.

It bumps dependencies and introduces a Channel multiplexer. Long story short, Each Request made against deno gets assigned an Uuid, which allows us to send the response to the right requester.

During this refactoring, we've also seen an issue that would happen when the TS runtime would try to return javascript Errors.

Since an Error is not iterable, it would not pass the Deno -> Rust fence because we rely on serialization. We thus catch errros and turn them into an { message, name, stack } structure, that we send to the deno side.

Moreover this commit reworks the Query Planning instanciation and allows us to return clearer error messages.