### PR TITLE
fix: unknown operation name

### DIFF
--- a/federation-2/router-bridge/js-src/plan.ts
+++ b/federation-2/router-bridge/js-src/plan.ts
@@ -86,9 +86,16 @@ export class BridgeQueryPlanner {
       );
     } catch (e) {
       // operationFromDocument throws GraphQLError
-      const statsReportKey = e.message.startsWith("Unknown operation named")
-        ? UNKNOWN_OPERATION
-        : VALIDATION_FAILURE;
+
+      let statsReportKey = VALIDATION_FAILURE;
+
+      if (
+        e.message.startsWith("Unknown operation named") ||
+        e.message.startsWith("Must provide operation name")
+      ) {
+        statsReportKey = UNKNOWN_OPERATION;
+      }
+
       return {
         usageReporting: {
           statsReportKey,

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -369,6 +369,7 @@ mod tests {
 
     const QUERY: &str = include_str!("testdata/query.graphql");
     const QUERY2: &str = include_str!("testdata/query2.graphql");
+    const MULTIPLE_QUERIES: &str = include_str!("testdata/query_with_multiple_operations.graphql");
     const NAMED_QUERY: &str = include_str!("testdata/named_query.graphql");
     const SCHEMA: &str = include_str!("testdata/schema.graphql");
 
@@ -396,6 +397,25 @@ mod tests {
 
         let payload = planner
             .plan(NAMED_QUERY.to_string(), None)
+            .await
+            .unwrap()
+            .into_result()
+            .unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&payload.data).unwrap());
+        insta::assert_snapshot!(serde_json::to_string_pretty(&payload.usage_reporting).unwrap());
+    }
+
+    #[tokio::test]
+    async fn named_query_with_several_choices_works() {
+        let planner = Planner::<serde_json::Value>::new(SCHEMA.to_string())
+            .await
+            .unwrap();
+
+        let payload = planner
+            .plan(
+                MULTIPLE_QUERIES.to_string(),
+                Some("MyFirstName".to_string()),
+            )
             .await
             .unwrap()
             .into_result()
@@ -501,6 +521,29 @@ mod tests {
 
         assert_eq!(
             "Unknown operation named \"ThisOperationNameDoesntExist\"",
+            payload.errors[0].message.as_ref().clone().unwrap()
+        );
+        assert_eq!(
+            "## GraphQLUnknownOperationName\n",
+            payload.usage_reporting.unwrap().stats_report_key
+        );
+    }
+
+    #[tokio::test]
+    async fn must_provide_operation_name_errors_return_the_right_usage_reporting_data() {
+        let planner = Planner::<serde_json::Value>::new(SCHEMA.to_string())
+            .await
+            .unwrap();
+
+        let payload = planner
+            .plan(MULTIPLE_QUERIES.to_string(), None)
+            .await
+            .unwrap()
+            .into_result()
+            .unwrap_err();
+
+        assert_eq!(
+            "Must provide operation name if query contains multiple operations.",
             payload.errors[0].message.as_ref().clone().unwrap()
         );
         assert_eq!(

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__named_query_with_several_choices_works-2.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__named_query_with_several_choices_works-2.snap
@@ -1,0 +1,27 @@
+---
+source: router-bridge/src/planner.rs
+expression: "serde_json::to_string_pretty(&payload.usage_reporting).unwrap()"
+---
+{
+  "statsReportKey": "# MyFirstName\nquery MyFirstName{me{name{first}}}",
+  "referencedFieldsByType": {
+    "Query": {
+      "fieldNames": [
+        "me"
+      ],
+      "isInterface": false
+    },
+    "User": {
+      "fieldNames": [
+        "name"
+      ],
+      "isInterface": false
+    },
+    "Name": {
+      "fieldNames": [
+        "first"
+      ],
+      "isInterface": false
+    }
+  }
+}

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__named_query_with_several_choices_works.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__named_query_with_several_choices_works.snap
@@ -1,0 +1,15 @@
+---
+source: router-bridge/src/planner.rs
+expression: "serde_json::to_string_pretty(&payload.data).unwrap()"
+---
+{
+  "kind": "QueryPlan",
+  "node": {
+    "kind": "Fetch",
+    "serviceName": "accounts",
+    "variableUsages": [],
+    "operation": "query MyFirstName__accounts__0{me{name{first}}}",
+    "operationKind": "query",
+    "operationName": "MyFirstName__accounts__0"
+  }
+}

--- a/federation-2/router-bridge/src/testdata/query_with_multiple_operations.graphql
+++ b/federation-2/router-bridge/src/testdata/query_with_multiple_operations.graphql
@@ -1,0 +1,16 @@
+query MyFullName {
+  me {
+    name {
+      first
+      last
+    }
+  }
+}
+
+query MyFirstName {
+  me {
+    name {
+      first
+    }
+  }
+}


### PR DESCRIPTION
As correctly pointed out by @glasser, The previous behavior handled Unknown provided operation name, but not Missing operation name when one was required.

This PR fixes it, and adds tests.