### PR TITLE
chore(router-bridge): Update pkg metadata to use `Elastic-2.0` SPDX id

### DIFF
--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -7,7 +7,7 @@ description = "JavaScript bridge for the Apollo Router"
 homepage = "https://www.apollographql.com/apollo-federation/"
 documentation = "https://apollographql.com/docs/federation/"
 repository = "https://github.com/apollographql/federation/"
-license-file = "./LICENSE"
+license = "Elastic-2.0"
 readme = "README.md"
 
 include = [

--- a/federation-2/router-bridge/package-lock.json
+++ b/federation-2/router-bridge/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@apollo/router-bridge",
       "version": "2.0.0-alpha.6",
-      "license": "SEE LICENSE IN ./LICENSE",
+      "license": "Elastic-2.0",
       "dependencies": {
         "@apollo/core-schema": "^0.3.0",
         "@apollo/query-planner": "2.0.1",

--- a/federation-2/router-bridge/package.json
+++ b/federation-2/router-bridge/package.json
@@ -21,7 +21,7 @@
     "directory": "router-bridge/"
   },
   "author": "Apollo <packages@apollographql.com>",
-  "license": "SEE LICENSE IN ./LICENSE",
+  "license": "Elastic-2.0",
   "engines": {
     "node": ">=12.13.0 <17.0",
     "npm": ">=7 <9"


### PR DESCRIPTION
In the same spirit as https://github.com/apollographql/router/pull/987.

Since `Elastic-2.0` SPDX identifiers now exist in the [SPDX License List],
we can use them in place of the `license-file` that we had been using
previously.

[SPDX License List]: https://spdx.org/licenses/

Relates to: https://github.com/apollographql/router/issues/418