### PR TITLE
Update instructions for releasing supergraph component

### DIFF
--- a/federation-2/harmonizer/RELEASE_CHECKLIST.md
+++ b/federation-2/harmonizer/RELEASE_CHECKLIST.md
@@ -14,7 +14,7 @@ None of the `federation-rs` packages currently maintain changelogs as they are l
 1. Run `PUBSLUG=composition@v{version}` where `{version}` is the new version you're bumping to. The major version should NOT be 0, it should be 2.
 1. Run `git checkout main && git stash && git pull && git checkout -b $PUBSLUG`.
 1. Update the version of `@apollo/composition` in `./harmonizer-2/package.json`
-1. Run `cargo xtask dist` from the root of `federation-rs`
+1. Run `cargo xtask dist --debug` from the root of `federation-rs`
 1. Push up a commit containing the version bumps with the message `release: $PUBSLUG`
 1. Wait for tests to pass on the PR
 1. Merge your PR to `main`
@@ -23,7 +23,14 @@ None of the `federation-rs` packages currently maintain changelogs as they are l
 
 1. Once merged, run `git checkout main && git pull`
 1. Run `cargo xtask tag --package $PUBSLUG --real-publish`
+   - **NOTE** If you get an error, you might need to run `git fetch --tags -f` to ensure the remote tags match the local tags
 1. Wait for CI to build and publish `harmonizer` to crates.io and `supergraph` to `federation-rs` GitHub releases.
+
+### Tag the `latest-2` release so rover automatically downloads the new version
+
+1. Run `git tag -d composition-latest-2 && git tag -a composition-latest-2 -m v{version} && git push --tags -f` replacing `{version}` with the version of composition.
+
+TODO: tag latest-2 / latest-1
 
 ## Troubleshooting a release
 

--- a/federation-2/harmonizer/RELEASE_CHECKLIST.md
+++ b/federation-2/harmonizer/RELEASE_CHECKLIST.md
@@ -23,7 +23,6 @@ None of the `federation-rs` packages currently maintain changelogs as they are l
 
 1. Once merged, run `git checkout main && git pull`
 1. Run `cargo xtask tag --package $PUBSLUG --real-publish`
-   - **NOTE** If you get an error, you might need to run `git fetch --tags -f` to ensure the remote tags match the local tags
 1. Wait for CI to build and publish `harmonizer` to crates.io and `supergraph` to `federation-rs` GitHub releases.
 
 ### Tag the `latest-2` release so rover automatically downloads the new version

--- a/federation-2/harmonizer/RELEASE_CHECKLIST.md
+++ b/federation-2/harmonizer/RELEASE_CHECKLIST.md
@@ -30,8 +30,6 @@ None of the `federation-rs` packages currently maintain changelogs as they are l
 
 1. Run `git tag -d composition-latest-2 && git tag -a composition-latest-2 -m v{version} && git push --tags -f` replacing `{version}` with the version of composition.
 
-TODO: tag latest-2 / latest-1
-
 ## Troubleshooting a release
 
 Mistakes happen. Most of these release steps are recoverable if you mess up.


### PR DESCRIPTION
1. Use `--debug` in `cargo xtask dist` so `Cargo.lock` can be updated. Without that param, you'll get the following error of sadness:
    ```
    ➜ cargo xtask dist
        Finished dev [unoptimized + debuginfo] target(s) in 0.04s
        Running `target/debug/xtask dist`
    info: running `cargo build --release --locked --target x86_64-apple-darwin` in `/Users/weatherman/code/apollographql/federation-rs/federation-1`
    info: running `cargo build --release --locked --target x86_64-apple-darwin` in `/Users/weatherman/code/apollographql/federation-rs/federation-2`
    info: running `cargo build --release --locked --target x86_64-apple-darwin` in `/Users/weatherman/code/apollographql/federation-rs/federation-2/router-bridge`
    error: the lock file /Users/weatherman/code/apollographql/federation-rs/federation-2/Cargo.lock needs to be updated but --locked was passed to prevent this
    If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.

    Error: Could not run command in `/Users/weatherman/code/apollographql/federation-rs/federation-2/router-bridge`

    Caused by:
        0: Encountered an issue while executing `cargo build --release --locked --target x86_64-apple-darwin`
        1: Exited with status code 101
    ```
1. Add instructions for tagging `latest-2` release so the supergraph component is downloaded by rover