### PR TITLE
chore: fixes xtask tag syncing

### DIFF
--- a/xtask/src/commands/tag.rs
+++ b/xtask/src/commands/tag.rs
@@ -23,8 +23,6 @@ impl Tag {
         let git_runner = GitRunner::new(verbose)?;
         git_runner.can_tag()?;
         let cargo_runner = CargoRunner::new(verbose)?;
-        cargo_runner.test_all()?;
-        cargo_runner.lint_all()?;
         cargo_runner.build_all(&Target::Other, false)?;
         git_runner.tag_release(&self.package, !self.real_publish)?;
         Ok(())

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -14,7 +14,7 @@ lazy_static! {
 #[macro_export]
 macro_rules! info {
     ($msg:expr $(, $($tokens:tt)* )?) => {{
-        let info_prefix = ansi_term::Colour::White.bold().paint("info:");
+        let info_prefix = ansi_term::Colour::White.bold().paint("ℹ️ info:");
         eprintln!(concat!("{} ", $msg), &info_prefix $(, $($tokens)*)*);
     }};
 }


### PR DESCRIPTION
fixes #131 by using `git fetch --tags --force` instead of `git fetch --tags` in order to clobber any local and outdated `composition-latest-{0,2}` tags. 

also in this PR for fun
- added some documentation
- removed mandatory lints and tests from running the tags 
  - my thinking here is that we already ensure a clean git history before tagging, and we run tests/lints in CI before cutting a release anyway - running them again locally is just too much