### PR TITLE
chore: attempt to force host_cpu to arm

### DIFF
--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -48,6 +48,10 @@ impl Target {
         Self::MacOSAmd64 == *self || Self::MacOSAarch64 == *self
     }
 
+    pub(crate) fn is_arm_macos(&self) -> bool {
+        Self::MacOSAarch64 == *self
+    }
+
     pub(crate) fn is_linux(&self) -> bool {
         Self::LinuxAarch64 == *self || Self::LinuxUnknownGnu == *self
     }
@@ -74,6 +78,9 @@ impl Target {
 
             env.insert("OPENSSL_ROOT_DIR".to_string(), openssl_path.to_string());
             env.insert("OPENSSL_STATIC".to_string(), "1".to_string());
+            if self.is_arm_macos() {
+                env.insert("GN_ARGS".to_string(), "host_cpu=\"arm64\"".to_string());
+            }
         } else if self.is_windows() {
             env.insert(
                 "RUSTFLAGS".to_string(),


### PR DESCRIPTION
by setting `GN_ARGS="host_cpu=\"arm64\"` and hoping for the best (from [this issue](https://github.com/denoland/rusty_v8/issues/520)). i'm hoping we don't need to build v8 from source and that this will just correctly create the snapshots