### PR TITLE
support defer in introspection queries

### DIFF
--- a/federation-2/router-bridge/js-src/do_introspect.ts
+++ b/federation-2/router-bridge/js-src/do_introspect.ts
@@ -1,3 +1,4 @@
+import { QueryPlannerConfig } from "@apollo/query-planner";
 import type { batchIntrospect } from ".";
 import type { OperationResult } from "./types";
 
@@ -11,6 +12,7 @@ declare let bridge: { batchIntrospect: typeof batchIntrospect };
 declare let done: (operationResult: OperationResult) => void;
 declare let sdl: string;
 declare let queries: string[];
+declare let config: QueryPlannerConfig;
 
 if (!sdl) {
   done({
@@ -19,7 +21,7 @@ if (!sdl) {
 }
 
 try {
-  const introspected = bridge.batchIntrospect(sdl, queries);
+  const introspected = bridge.batchIntrospect(sdl, queries, config);
   done({ Ok: introspected });
 } catch (err) {
   done({

--- a/federation-2/router-bridge/js-src/introspection.ts
+++ b/federation-2/router-bridge/js-src/introspection.ts
@@ -7,10 +7,12 @@ import {
 } from "graphql";
 
 import { buildSchema } from "@apollo/federation-internals";
+import { QueryPlannerConfig } from "@apollo/query-planner";
 
 export function batchIntrospect(
   sdl: string,
-  queries: string[]
+  queries: string[],
+  options: QueryPlannerConfig
 ): ExecutionResult[] {
   let schema: GraphQLSchema;
   try {
@@ -20,7 +22,9 @@ export function batchIntrospect(
     // Now try to get the API schema
     let composedSchema = buildSchema(sdl);
     let apiSchema = composedSchema.toAPISchema();
-    schema = apiSchema.toGraphQLJSSchema();
+    schema = apiSchema.toGraphQLJSSchema({
+      includeDefer: options.deferStreamSupport?.enableDefer,
+    });
   } catch (e) {
     return Array(queries.length).fill({
       errors: [e],
@@ -34,7 +38,11 @@ export function batchIntrospect(
   return queries.map((query) => introspectOne(schema, query));
 }
 
-export function introspect(sdl: string, query: string): ExecutionResult {
+export function introspect(
+  sdl: string,
+  query: string,
+  options: QueryPlannerConfig
+): ExecutionResult {
   let schema: GraphQLSchema;
   try {
     // First go through regular schema parsing
@@ -43,7 +51,9 @@ export function introspect(sdl: string, query: string): ExecutionResult {
     // Now try to get the API schema
     let composedSchema = buildSchema(sdl);
     let apiSchema = composedSchema.toAPISchema();
-    schema = apiSchema.toGraphQLJSSchema();
+    schema = apiSchema.toGraphQLJSSchema({
+      includeDefer: options.deferStreamSupport?.enableDefer,
+    });
   } catch (e) {
     return {
       errors: [e],

--- a/federation-2/router-bridge/src/introspect.rs
+++ b/federation-2/router-bridge/src/introspect.rs
@@ -2,8 +2,8 @@
 # Run introspection against a GraphQL schema and obtain the result
 */
 
-use crate::error::Error;
 use crate::js::Js;
+use crate::{error::Error, planner::QueryPlannerConfig};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use thiserror::Error;
@@ -82,10 +82,15 @@ pub type IntrospectionResult = Result<Vec<IntrospectionResponse>, IntrospectionE
 /// The `batch_introspect` function receives a [`string`] representing the SDL and invokes JavaScript
 /// introspection on it, with the `queries` to run against the SDL.
 ///
-pub fn batch_introspect(sdl: &str, queries: Vec<String>) -> Result<IntrospectionResult, Error> {
+pub fn batch_introspect(
+    sdl: &str,
+    queries: Vec<String>,
+    config: QueryPlannerConfig,
+) -> Result<IntrospectionResult, Error> {
     Js::new()
         .with_parameter("sdl", sdl)?
         .with_parameter("queries", queries)?
+        .with_parameter("config", config)?
         .execute::<IntrospectionResult>(
             "do_introspect",
             include_str!("../js-dist/do_introspect.js"),
@@ -94,7 +99,10 @@ pub fn batch_introspect(sdl: &str, queries: Vec<String>) -> Result<Introspection
 
 #[cfg(test)]
 mod tests {
-    use crate::introspect::batch_introspect;
+    use crate::{
+        introspect::batch_introspect,
+        planner::{DeferStreamSupport, QueryPlannerConfig},
+    };
     #[test]
     fn it_works() {
         let raw_sdl = r#"schema
@@ -107,8 +115,12 @@ mod tests {
         }
         "#;
 
-        let introspected =
-            batch_introspect(raw_sdl, vec![DEFAULT_INTROSPECTION_QUERY.to_string()]).unwrap();
+        let introspected = batch_introspect(
+            raw_sdl,
+            vec![DEFAULT_INTROSPECTION_QUERY.to_string()],
+            QueryPlannerConfig::default(),
+        )
+        .unwrap();
         insta::assert_snapshot!(serde_json::to_string(&introspected).unwrap());
     }
 
@@ -123,6 +135,7 @@ mod tests {
                 query: Query
             }",
             vec![DEFAULT_INTROSPECTION_QUERY.to_string()],
+            QueryPlannerConfig::default(),
         )
         .expect("an uncaught deno error occured")
         .expect("a javascript land error happened");
@@ -141,6 +154,7 @@ mod tests {
                 query: Query
             }",
             vec![DEFAULT_INTROSPECTION_QUERY.to_string()],
+            QueryPlannerConfig::default(),
         )
         .expect("an uncaught deno error occured")
         .expect("a javascript land error happened");
@@ -249,4 +263,53 @@ fragment TypeRef on __Type {
     }
 }
 "#;
+
+    #[test]
+    fn defer_in_introspection() {
+        let raw_sdl = r#"schema
+        {
+          query: Query
+        }
+
+        type Query {
+          hello: String
+        }
+        "#;
+
+        let introspected = batch_introspect(
+            raw_sdl,
+            vec![r#"query {
+                __schema {
+                  directives {
+                    name
+                    locations
+                  }
+                }
+              }"#
+            .to_string()],
+            QueryPlannerConfig::default(),
+        )
+        .unwrap();
+        insta::assert_snapshot!(serde_json::to_string(&introspected).unwrap());
+
+        let introspected = batch_introspect(
+            raw_sdl,
+            vec![r#"query {
+                __schema {
+                  directives {
+                    name
+                    locations
+                  }
+                }
+              }"#
+            .to_string()],
+            QueryPlannerConfig {
+                defer_stream_support: Some(DeferStreamSupport {
+                    enable_defer: Some(true),
+                }),
+            },
+        )
+        .unwrap();
+        insta::assert_snapshot!(serde_json::to_string(&introspected).unwrap());
+    }
 }


### PR DESCRIPTION
Fix https://github.com/apollographql/router/issues/1544

introspection queries can get a list of supported directives, so if the
defer directive is active in query planning, it should be active in
introspection as well