### PR TITLE
router-bridge: Update to now-published federation 2.1.0 packages

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -168,6 +168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "ctor"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +261,12 @@ dependencies = [
  "rustc_version 0.4.0",
  "syn",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
@@ -611,6 +627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +701,18 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -803,6 +840,7 @@ dependencies = [
  "deno_core",
  "futures",
  "insta",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "thiserror",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { version = "0.8.2", features = ["v4", "serde"] }
 [dev-dependencies]
 futures = "0.3.21"
 insta = "1.8.0"
+pretty_assertions = "1.2.1"
 tracing-test = "0.2.1"
 
 [build-dependencies]

--- a/federation-2/router-bridge/build.rs
+++ b/federation-2/router-bridge/build.rs
@@ -5,15 +5,22 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
+    // only do `npm` related stuff if we're _not_ publishing to crates.io
+    if std::fs::metadata("./package.json").is_ok() {
+        println!("cargo:rerun-if-changed=js-src");
+
+        let current_dir = std::env::current_dir().unwrap();
+
+        update_bridge(&current_dir);
+    } else {
+        // the crate has been published, no need to rerun
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+
     let out_dir: PathBuf = std::env::var_os("OUT_DIR")
         .expect("$OUT_DIR not set.")
         .into();
-    println!("cargo:rerun-if-changed=js-src");
-    let current_dir = std::env::current_dir().unwrap();
-    // only do `npm` related stuff if we're _not_ publishing to crates.io
-    if std::fs::metadata("./package.json").is_ok() {
-        update_bridge(&current_dir);
-    }
+
     create_snapshot(&out_dir);
 }
 

--- a/federation-2/router-bridge/js-src/introspection.ts
+++ b/federation-2/router-bridge/js-src/introspection.ts
@@ -23,7 +23,7 @@ export function batchIntrospect(
     let composedSchema = buildSchema(sdl);
     let apiSchema = composedSchema.toAPISchema();
     schema = apiSchema.toGraphQLJSSchema({
-      includeDefer: options.deferStreamSupport?.enableDefer,
+      includeDefer: options.incrementalDelivery?.enableDefer,
     });
   } catch (e) {
     return Array(queries.length).fill({
@@ -52,7 +52,7 @@ export function introspect(
     let composedSchema = buildSchema(sdl);
     let apiSchema = composedSchema.toAPISchema();
     schema = apiSchema.toGraphQLJSSchema({
-      includeDefer: options.deferStreamSupport?.enableDefer,
+      includeDefer: options.incrementalDelivery?.enableDefer,
     });
   } catch (e) {
     return {

--- a/federation-2/router-bridge/js-src/plan.ts
+++ b/federation-2/router-bridge/js-src/plan.ts
@@ -57,7 +57,7 @@ export class BridgeQueryPlanner {
     this.composedSchema = schema;
     const apiSchema = this.composedSchema.toAPISchema();
     this.apiSchema = apiSchema.toGraphQLJSSchema({
-      includeDefer: options.deferStreamSupport?.enableDefer,
+      includeDefer: options.incrementalDelivery?.enableDefer,
     });
     this.planner = new QueryPlanner(this.composedSchema, options);
   }

--- a/federation-2/router-bridge/package-lock.json
+++ b/federation-2/router-bridge/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "@apollo/router-bridge",
-      "version": "2.0.0-alpha.6",
+      "version": "2.1.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@apollo/core-schema": "^0.3.0",
-        "@apollo/federation-internals": "2.1.0-alpha.4",
-        "@apollo/query-planner": "2.1.0-alpha.4",
+        "@apollo/federation-internals": "2.1.0",
+        "@apollo/query-planner": "2.1.0",
         "@apollo/utils.usagereporting": "^1.0.0",
         "apollo-reporting-protobuf": "^3.3.1",
         "fast-text-encoding": "1.0.3",
@@ -51,11 +51,10 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.0-alpha.4.tgz",
-      "integrity": "sha512-Buw8TDvblTCAFmpk3ygUlO0HECoelLTi8XSzsj59DgmttjVAD/aU7KkVXmIrc4PjpcRDBczCbX81AJeyDLry3A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.0.tgz",
+      "integrity": "sha512-6QKiDNr1yd9n6Bi2MUCjVQdMlgS+fA6EFkToD9S0vRowKXtZDNMVxPqh9pZtUvNl8UCRiF0dFjfV2QwFk54YMA==",
       "dependencies": {
-        "@apollo/core-schema": "~0.3.0",
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
       },
@@ -92,11 +91,11 @@
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.0-alpha.4.tgz",
-      "integrity": "sha512-c0o5AcALl8e2HMAwYaLHFNbB/VF9i3Ih6cIqL4fG89mcKwl0or4KuIBG9hcJ0fWb+LHlX23a+53oogi2AzwL8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.0.tgz",
+      "integrity": "sha512-5vEyUmrPSBldL9o1ySLshGh37VzY/9lgPlvEmqgRT43fmld21FozhxqfviF+D/9dVQWr23XuU+QfENoba8AgRQ==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.1.0-alpha.4",
+        "@apollo/federation-internals": "^2.1.0",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       },
@@ -108,12 +107,12 @@
       }
     },
     "node_modules/@apollo/query-planner": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.0-alpha.4.tgz",
-      "integrity": "sha512-IIwMqAdam7vmwalb2oRzdugw7fXuTXVAWENiuC3AxFfcxyt/kAqoMVKvH5Ezc/Z+Dj9F7/Ux8nSYaz7h1mqGtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.0.tgz",
+      "integrity": "sha512-Ks1rwtCcUiy9U3VnH7PJB2/o8kmAsJ/iwoTLt8NIBxL4CotILG21UUBrXHI/HYLoKVObTGpHA5vTV/Jy+d1gHg==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.1.0-alpha.4",
-        "@apollo/query-graphs": "^2.1.0-alpha.4",
+        "@apollo/federation-internals": "^2.1.0",
+        "@apollo/query-graphs": "^2.1.0",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^28.0.0"
@@ -2336,11 +2335,10 @@
       }
     },
     "@apollo/federation-internals": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.0-alpha.4.tgz",
-      "integrity": "sha512-Buw8TDvblTCAFmpk3ygUlO0HECoelLTi8XSzsj59DgmttjVAD/aU7KkVXmIrc4PjpcRDBczCbX81AJeyDLry3A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.0.tgz",
+      "integrity": "sha512-6QKiDNr1yd9n6Bi2MUCjVQdMlgS+fA6EFkToD9S0vRowKXtZDNMVxPqh9pZtUvNl8UCRiF0dFjfV2QwFk54YMA==",
       "requires": {
-        "@apollo/core-schema": "~0.3.0",
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
       }
@@ -2366,22 +2364,22 @@
       }
     },
     "@apollo/query-graphs": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.0-alpha.4.tgz",
-      "integrity": "sha512-c0o5AcALl8e2HMAwYaLHFNbB/VF9i3Ih6cIqL4fG89mcKwl0or4KuIBG9hcJ0fWb+LHlX23a+53oogi2AzwL8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.0.tgz",
+      "integrity": "sha512-5vEyUmrPSBldL9o1ySLshGh37VzY/9lgPlvEmqgRT43fmld21FozhxqfviF+D/9dVQWr23XuU+QfENoba8AgRQ==",
       "requires": {
-        "@apollo/federation-internals": "^2.1.0-alpha.4",
+        "@apollo/federation-internals": "^2.1.0",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       }
     },
     "@apollo/query-planner": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.0-alpha.4.tgz",
-      "integrity": "sha512-IIwMqAdam7vmwalb2oRzdugw7fXuTXVAWENiuC3AxFfcxyt/kAqoMVKvH5Ezc/Z+Dj9F7/Ux8nSYaz7h1mqGtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.0.tgz",
+      "integrity": "sha512-Ks1rwtCcUiy9U3VnH7PJB2/o8kmAsJ/iwoTLt8NIBxL4CotILG21UUBrXHI/HYLoKVObTGpHA5vTV/Jy+d1gHg==",
       "requires": {
-        "@apollo/federation-internals": "^2.1.0-alpha.4",
-        "@apollo/query-graphs": "^2.1.0-alpha.4",
+        "@apollo/federation-internals": "^2.1.0",
+        "@apollo/query-graphs": "^2.1.0",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^28.0.0"

--- a/federation-2/router-bridge/package-lock.json
+++ b/federation-2/router-bridge/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/router-bridge",
-  "version": "2.0.0-alpha.6",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/federation-2/router-bridge/package.json
+++ b/federation-2/router-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/router-bridge",
   "private": true,
-  "version": "2.0.0-alpha.6",
+  "version": "2.1.0",
   "description": "Apollo Router JS Bridge Entrypoint",
   "scripts": {
     "build": "make-dir bundled js-dist && rm -f tsconfig.tsbuildinfo && tsc --build --verbose && node esbuild/bundler.js && cp js-dist/runtime.js js-dist/do_api_schema.js js-dist/do_introspect.js js-dist/plan_worker.js js-dist/test_logger_worker.js bundled/",

--- a/federation-2/router-bridge/package.json
+++ b/federation-2/router-bridge/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@apollo/core-schema": "^0.3.0",
-    "@apollo/federation-internals": "2.1.0-alpha.4",
-    "@apollo/query-planner": "2.1.0-alpha.4",
+    "@apollo/federation-internals": "2.1.0",
+    "@apollo/query-planner": "2.1.0",
     "@apollo/utils.usagereporting": "^1.0.0",
     "apollo-reporting-protobuf": "^3.3.1",
     "fast-text-encoding": "1.0.3",

--- a/federation-2/router-bridge/src/introspect.rs
+++ b/federation-2/router-bridge/src/introspect.rs
@@ -101,7 +101,7 @@ pub fn batch_introspect(
 mod tests {
     use crate::{
         introspect::batch_introspect,
-        planner::{DeferStreamSupport, QueryPlannerConfig},
+        planner::{IncrementalDeliverySupport, QueryPlannerConfig},
     };
     #[test]
     fn it_works() {
@@ -109,7 +109,7 @@ mod tests {
         {
           query: Query
         }
-  
+
         type Query {
           hello: String
         }
@@ -220,7 +220,7 @@ fragment FullType on __Type {
         ...TypeRef
     }
 }
-    
+
 fragment InputValue on __InputValue {
     name
     description
@@ -304,7 +304,7 @@ fragment TypeRef on __Type {
               }"#
             .to_string()],
             QueryPlannerConfig {
-                defer_stream_support: Some(DeferStreamSupport {
+                incremental_delivery_support: Some(IncrementalDeliverySupport {
                     enable_defer: Some(true),
                 }),
             },

--- a/federation-2/router-bridge/src/introspect.rs
+++ b/federation-2/router-bridge/src/introspect.rs
@@ -304,7 +304,7 @@ fragment TypeRef on __Type {
               }"#
             .to_string()],
             QueryPlannerConfig {
-                incremental_delivery_support: Some(IncrementalDeliverySupport {
+                incremental_delivery: Some(IncrementalDeliverySupport {
                     enable_defer: Some(true),
                 }),
             },

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -488,13 +488,13 @@ pub struct QueryPlannerConfig {
     // (and it would be empty by default). Similarly, once we support @stream, grouping the options here will
     // make sense too.
     /// Option for `@defer` directive support
-    pub defer_stream_support: Option<DeferStreamSupport>,
+    pub incremental_delivery_support: Option<IncrementalDeliverySupport>,
 }
 
 impl Default for QueryPlannerConfig {
     fn default() -> Self {
         Self {
-            defer_stream_support: Some(DeferStreamSupport {
+            incremental_delivery_support: Some(IncrementalDeliverySupport {
                 enable_defer: Some(false),
             }),
         }
@@ -504,7 +504,7 @@ impl Default for QueryPlannerConfig {
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 /// Option for `@defer` directive support
-pub struct DeferStreamSupport {
+pub struct IncrementalDeliverySupport {
     /// Enables @defer support by the query planner.
     ///
     /// If set, then the query plan for queries having some @defer will contains some `DeferNode` (see `QueryPlan.ts`).


### PR DESCRIPTION
> Note: This merges into `abernix/router-bridge-direct-deps` #160, which itself merges into #159 

Ref: apollographql/federation#2105