### PR TITLE
router-bridge: Update to now-published federation 2.1.1 packages

### DIFF
--- a/federation-2/router-bridge/package-lock.json
+++ b/federation-2/router-bridge/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@apollo/router-bridge",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/router-bridge",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@apollo/core-schema": "^0.3.0",
-        "@apollo/federation-internals": "2.1.0",
-        "@apollo/query-planner": "2.1.0",
+        "@apollo/federation-internals": "2.1.1",
+        "@apollo/query-planner": "2.1.1",
         "@apollo/utils.usagereporting": "^1.0.0",
         "apollo-reporting-protobuf": "^3.3.1",
         "fast-text-encoding": "1.0.3",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.0.tgz",
-      "integrity": "sha512-6QKiDNr1yd9n6Bi2MUCjVQdMlgS+fA6EFkToD9S0vRowKXtZDNMVxPqh9pZtUvNl8UCRiF0dFjfV2QwFk54YMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.1.tgz",
+      "integrity": "sha512-ZFFUhWbSeMf+P+GVXj3srtGTFbA+hap0FSRHO+42su9XbCyq/siw7+DRNTuHUrwTFnC0Y2mtHuDWGZ/HiIMifg==",
       "dependencies": {
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
@@ -91,11 +91,11 @@
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.0.tgz",
-      "integrity": "sha512-5vEyUmrPSBldL9o1ySLshGh37VzY/9lgPlvEmqgRT43fmld21FozhxqfviF+D/9dVQWr23XuU+QfENoba8AgRQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.1.tgz",
+      "integrity": "sha512-unTRgO4XGh4ZJjIjuQQKHS/nNfD/NiuvjY8ZmAfA0lsVGIbQcigOKkMR7Gc8rDgQcmXUZE9UF8q2vWsY3MHa8Q==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.1.0",
+        "@apollo/federation-internals": "^2.1.1",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       },
@@ -107,12 +107,12 @@
       }
     },
     "node_modules/@apollo/query-planner": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.0.tgz",
-      "integrity": "sha512-Ks1rwtCcUiy9U3VnH7PJB2/o8kmAsJ/iwoTLt8NIBxL4CotILG21UUBrXHI/HYLoKVObTGpHA5vTV/Jy+d1gHg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.1.tgz",
+      "integrity": "sha512-PL39OLc0NSZMwEZNUpb8sLnuNChb0TfzkQnXLBuOBgQ9g4eKCzO359+pZBJszMr3G+zXEeyH/FTfk4k5E7RJSQ==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.1.0",
-        "@apollo/query-graphs": "^2.1.0",
+        "@apollo/federation-internals": "^2.1.1",
+        "@apollo/query-graphs": "^2.1.1",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^28.0.0"
@@ -2335,9 +2335,9 @@
       }
     },
     "@apollo/federation-internals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.0.tgz",
-      "integrity": "sha512-6QKiDNr1yd9n6Bi2MUCjVQdMlgS+fA6EFkToD9S0vRowKXtZDNMVxPqh9pZtUvNl8UCRiF0dFjfV2QwFk54YMA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.1.1.tgz",
+      "integrity": "sha512-ZFFUhWbSeMf+P+GVXj3srtGTFbA+hap0FSRHO+42su9XbCyq/siw7+DRNTuHUrwTFnC0Y2mtHuDWGZ/HiIMifg==",
       "requires": {
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
@@ -2364,22 +2364,22 @@
       }
     },
     "@apollo/query-graphs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.0.tgz",
-      "integrity": "sha512-5vEyUmrPSBldL9o1ySLshGh37VzY/9lgPlvEmqgRT43fmld21FozhxqfviF+D/9dVQWr23XuU+QfENoba8AgRQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.1.1.tgz",
+      "integrity": "sha512-unTRgO4XGh4ZJjIjuQQKHS/nNfD/NiuvjY8ZmAfA0lsVGIbQcigOKkMR7Gc8rDgQcmXUZE9UF8q2vWsY3MHa8Q==",
       "requires": {
-        "@apollo/federation-internals": "^2.1.0",
+        "@apollo/federation-internals": "^2.1.1",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0"
       }
     },
     "@apollo/query-planner": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.0.tgz",
-      "integrity": "sha512-Ks1rwtCcUiy9U3VnH7PJB2/o8kmAsJ/iwoTLt8NIBxL4CotILG21UUBrXHI/HYLoKVObTGpHA5vTV/Jy+d1gHg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.1.1.tgz",
+      "integrity": "sha512-PL39OLc0NSZMwEZNUpb8sLnuNChb0TfzkQnXLBuOBgQ9g4eKCzO359+pZBJszMr3G+zXEeyH/FTfk4k5E7RJSQ==",
       "requires": {
-        "@apollo/federation-internals": "^2.1.0",
-        "@apollo/query-graphs": "^2.1.0",
+        "@apollo/federation-internals": "^2.1.1",
+        "@apollo/query-graphs": "^2.1.1",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^28.0.0"

--- a/federation-2/router-bridge/package.json
+++ b/federation-2/router-bridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apollo/router-bridge",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Apollo Router JS Bridge Entrypoint",
   "scripts": {
     "build": "make-dir bundled js-dist && rm -f tsconfig.tsbuildinfo && tsc --build --verbose && node esbuild/bundler.js && cp js-dist/runtime.js js-dist/do_api_schema.js js-dist/do_introspect.js js-dist/plan_worker.js js-dist/test_logger_worker.js bundled/",
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@apollo/core-schema": "^0.3.0",
-    "@apollo/federation-internals": "2.1.0",
-    "@apollo/query-planner": "2.1.0",
+    "@apollo/federation-internals": "2.1.1",
+    "@apollo/query-planner": "2.1.1",
     "@apollo/utils.usagereporting": "^1.0.0",
     "apollo-reporting-protobuf": "^3.3.1",
     "fast-text-encoding": "1.0.3",


### PR DESCRIPTION
Similar spirit as previous PR for [2.1.0].

[2.1.0]: https://github.com/apollographql/federation-rs/pull/161
[2.1.1]: https://github.com/apollographql/federation/pull/2122
