### PR TITLE
Always generate query plan even when pretty plan serialization fails

### DIFF
--- a/federation-2/router-bridge/js-src/plan.ts
+++ b/federation-2/router-bridge/js-src/plan.ts
@@ -137,7 +137,21 @@ export class BridgeQueryPlanner {
       operationDerivedData.signature
     }`;
     const queryPlan = this.planner.buildQueryPlan(operation);
-    const formattedQueryPlan = prettyFormatQueryPlan(queryPlan);
+    let formattedQueryPlan: string | null;
+    try {
+      formattedQueryPlan = prettyFormatQueryPlan(queryPlan);
+    } catch (err) {
+      // We have decided that since we HAVE a query plan (above), there is
+      // absolutely no reason to interrupt the ability to proceed just because
+      // we wanted a pretty-printed version of the query planner here.  Therefore
+      // we will just proceed without the pretty printed bits.
+      logger.warn(
+        `Couldn't generate pretty query plan for ${
+          operationName ? "operation " + operationName : "anonymous operation"
+        }: ${err}`
+      );
+      formattedQueryPlan = null;
+    }
 
     return {
       usageReporting: {


### PR DESCRIPTION
We recently added the ability for the Router to have access to the "pretty
printed" query plan in https://github.com/apollographql/federation-rs/pull/154.

The `prettyFormatQueryPlan` function can throw an error (internally) when
its unable to print the plan, however, no failure to produce a pretty
printed query plan should be severe enough stop execution of an otherwise
valid plan.  The pretty printed aspect is purely for diagnostics purposes
and for consumption by humans.
