### PR TITLE
try out an idea for protecting the query planner from abuse

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -849,7 +849,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-test",
- "uuid",
  "which",
 ]
 
@@ -1396,16 +1395,6 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
  "serde",
 ]
 

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -35,7 +35,6 @@ tokio = { version = "1.17.0", features = ["full"] }
 tower = { version = "0.4.12", features = ["full"] }
 tower-service = "0.3.1"
 tracing = "0.1.33"
-uuid = { version = "0.8.2", features = ["v4", "serde"] }
 
 [dev-dependencies]
 futures = "0.3.21"

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -633,7 +633,7 @@ mod tests {
 
         assert_eq!(
             "Syntax Error: Unexpected Name \"this\".",
-            payload.errors[0].message.as_ref().clone().unwrap()
+            payload.errors[0].message.as_ref().unwrap()
         );
         assert_eq!(
             "## GraphQLParseFailure\n",
@@ -671,7 +671,7 @@ mod tests {
 
         assert_eq!(
             "Cannot spread fragment \"thatUserFragment1\" within itself via \"thatUserFragment2\".",
-            payload.errors[0].message.as_ref().clone().unwrap()
+            payload.errors[0].message.as_ref().unwrap()
         );
         assert_eq!(
             "## GraphQLValidationFailure\n",
@@ -698,7 +698,7 @@ mod tests {
 
         assert_eq!(
             "Unknown operation named \"ThisOperationNameDoesntExist\"",
-            payload.errors[0].message.as_ref().clone().unwrap()
+            payload.errors[0].message.as_ref().unwrap()
         );
         assert_eq!(
             "## GraphQLUnknownOperationName\n",
@@ -722,7 +722,7 @@ mod tests {
 
         assert_eq!(
             "Must provide operation name if query contains multiple operations.",
-            payload.errors[0].message.as_ref().clone().unwrap()
+            payload.errors[0].message.as_ref().unwrap()
         );
         assert_eq!(
             "## GraphQLUnknownOperationName\n",
@@ -746,7 +746,7 @@ mod tests {
 
         assert_eq!(
             "This anonymous operation must be the only defined operation.",
-            payload.errors[0].message.as_ref().clone().unwrap()
+            payload.errors[0].message.as_ref().unwrap()
         );
         assert_eq!(
             "## GraphQLValidationFailure\n",
@@ -770,7 +770,7 @@ mod tests {
 
         assert_eq!(
             "Fragment \"thatUserFragment1\" is never used.",
-            payload.errors[0].message.as_ref().clone().unwrap()
+            payload.errors[0].message.as_ref().unwrap()
         );
         assert_eq!(
             "## GraphQLValidationFailure\n",

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -462,7 +462,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(tag = "kind")]
 enum PlanCmd {
     UpdateSchema {
@@ -476,7 +476,7 @@ enum PlanCmd {
     },
     Exit,
 }
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 /// Query planner configuration
 pub struct QueryPlannerConfig {
@@ -501,7 +501,7 @@ impl Default for QueryPlannerConfig {
     }
 }
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 /// Option for `@defer` directive support
 pub struct IncrementalDeliverySupport {

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -415,7 +415,7 @@ where
             }
             Ok(setup) => {
                 if let Some(error) = setup.errors {
-                    let _ = worker.send(PlanCmd::Exit).await;
+                    let _ = worker.send(None, PlanCmd::Exit).await;
                     return Err(error);
                 }
             }
@@ -456,7 +456,7 @@ where
                 .build()
                 .unwrap();
 
-            let _ = runtime.block_on(async move { worker_clone.send(PlanCmd::Exit).await });
+            let _ = runtime.block_on(async move { worker_clone.send(None, PlanCmd::Exit).await });
         })
         .join();
     }

--- a/federation-2/router-bridge/src/worker.rs
+++ b/federation-2/router-bridge/src/worker.rs
@@ -130,7 +130,7 @@ impl JsWorker {
         if let Some(payload) = self.unsent_queries.lock().await.remove(&id) {
             serde_json::from_value(payload).map_err(|e| Error::ParameterDeserialization {
                 message: format!("deno: couldn't deserialize response : `{:?}`", e),
-                id: format!("id: {id}"),
+                id,
             })
         } else {
             self.send(Some(id.clone()), command)
@@ -202,7 +202,7 @@ impl JsWorker {
 
         serde_json::from_value(payload).map_err(|e| Error::ParameterDeserialization {
             message: format!("deno: couldn't deserialize response : `{:?}`", e),
-            id: format!("id: {id}"),
+            id,
         })
     }
 

--- a/federation-2/router-bridge/src/worker.rs
+++ b/federation-2/router-bridge/src/worker.rs
@@ -312,7 +312,7 @@ mod worker_tests {
     }
 
     async fn run_logger() {
-        #[derive(Serialize, Deserialize, Debug)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
         enum Kind {
             Trace,
             Debug,
@@ -322,7 +322,7 @@ mod worker_tests {
             Exit,
         }
 
-        #[derive(Serialize, Deserialize, Debug)]
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
         struct Command {
             kind: Kind,
             message: Option<String>,


### PR DESCRIPTION
The idea is to maintain a HashSet of queries where we couldn't notify our requester that query planning has completed.

They become, effectively, blacklisted and the next time we receive that request, we just reject it.

This would help a lot with complex query planning.

The are some drawbacks with the approach though. There are many legitimate resons for a requester to disappear, so it seems harsh to always blacklist (see comments in code for ways to mitigate).

Anyway, I think it's worth exploring further and as a side effect I got rid of Uuid and rely on the rust hasher for ID generation.