### PR TITLE
router-bridge: Disable Deno snapshotting when docs.rs builds docs

### DIFF
--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -45,3 +45,11 @@ tracing-test = "0.2.1"
 [build-dependencies]
 deno_core = "0.142.0"
 which = "4.2.2"
+
+[features]
+# "fake" feature to disable V8 usage when building on docs.rs
+# See ./build.rs
+docsrs = []
+
+[package.metadata.docs.rs]
+features = ["docsrs"]

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -49,7 +49,7 @@ which = "4.2.2"
 [features]
 # "fake" feature to disable V8 usage when building on docs.rs
 # See ./build.rs
-docsrs = []
+docs_rs = []
 
 [package.metadata.docs.rs]
 features = ["docsrs"]

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -52,4 +52,4 @@ which = "4.2.2"
 docs_rs = []
 
 [package.metadata.docs.rs]
-features = ["docsrs"]
+features = ["docs_rs"]

--- a/federation-2/router-bridge/build.rs
+++ b/federation-2/router-bridge/build.rs
@@ -66,7 +66,7 @@ fn update_bridge(current_dir: &Path) {
         .success());
 }
 
-#[cfg(feature = "docsrs")]
+#[cfg(feature = "docs_rs")]
 fn create_snapshot(out_dir: &Path) {
     // If we're building on docs.rs we just create
     // an empty snapshot file and return, because `rusty_v8`
@@ -74,7 +74,7 @@ fn create_snapshot(out_dir: &Path) {
     std::fs::write(out_dir.join("query_runtime.snap"), &[]).unwrap();
 }
 
-#[cfg(not(feature = "docsrs"))]
+#[cfg(not(feature = "docs_rs"))]
 fn create_snapshot(out_dir: &Path) {
     use deno_core::{JsRuntime, RuntimeOptions};
     use std::fs::{read_to_string, File};

--- a/federation-2/router-bridge/build.rs
+++ b/federation-2/router-bridge/build.rs
@@ -69,7 +69,7 @@ fn update_bridge(current_dir: &Path) {
 #[cfg(feature = "docsrs")]
 fn create_snapshot(out_dir: &Path) {
     // If we're building on docs.rs we just create
-    // and empty snapshot file and return, because `rusty_v8`
+    // an empty snapshot file and return, because `rusty_v8`
     // doesn't actually compile on docs.rs
     std::fs::write(out_dir.join("query_runtime.snap"), &[]).unwrap();
 }

--- a/federation-2/router-bridge/build.rs
+++ b/federation-2/router-bridge/build.rs
@@ -1,6 +1,3 @@
-use deno_core::{JsRuntime, RuntimeOptions};
-use std::fs::{read_to_string, File};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -69,7 +66,20 @@ fn update_bridge(current_dir: &Path) {
         .success());
 }
 
+#[cfg(feature = "docsrs")]
 fn create_snapshot(out_dir: &Path) {
+    // If we're building on docs.rs we just create
+    // and empty snapshot file and return, because `rusty_v8`
+    // doesn't actually compile on docs.rs
+    std::fs::write(out_dir.join("query_runtime.snap"), &[]).unwrap();
+}
+
+#[cfg(not(feature = "docsrs"))]
+fn create_snapshot(out_dir: &Path) {
+    use deno_core::{JsRuntime, RuntimeOptions};
+    use std::fs::{read_to_string, File};
+    use std::io::Write;
+
     let options = RuntimeOptions {
         will_snapshot: true,
         ..Default::default()


### PR DESCRIPTION
This attempts to fix build errors like https://docs.rs/crate/apollo-router/1.0.0-rc.0/builds/629200 by imitating what Deno does in https://github.com/denoland/deno/blob/6bb72a80863ac3913d32ea21aae32dd327ce6b71/runtime/build.rs#L228-238