### PR TITLE
add support for deno memory controls in the router-bridge

### DIFF
--- a/federation-2/router-bridge/src/worker.rs
+++ b/federation-2/router-bridge/src/worker.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use async_channel::{bounded, Receiver, Sender};
-use deno_core::{op, Extension, JsRuntime, OpState, RuntimeOptions, Snapshot};
+use deno_core::{op, Extension, OpState};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
@@ -81,14 +81,8 @@ impl JsWorker {
                     Ok(())
                 })
                 .build();
-            // Initialize a runtime instance
-            let buffer = include_bytes!(concat!(env!("OUT_DIR"), "/query_runtime.snap"));
 
-            let mut js_runtime = JsRuntime::new(RuntimeOptions {
-                extensions: vec![my_ext],
-                startup_snapshot: Some(Snapshot::Static(buffer)),
-                ..Default::default()
-            });
+            let mut js_runtime = crate::js::build_js_runtime("query planner".to_string(), my_ext);
 
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()


### PR DESCRIPTION
This PR introduces support setting a minimum heap size for deno. An experimental flag:
  APOLLO_ROUTER_BRIDGE_EXPERIMENTAL_V8_INITIAL_HEAP_SIZE
is now supported which allows a default, initial heap limit for deno to be specified. If not specified, a default of 256M is used (which I believe is lower than the usual default of 1024M) and appropriate for most supergraph activities.

If introspection is enabled, the setting also applies to the deno introspection execution environment.

If the deno heap is running low, then it will be expanded by 1.25. There is no upper limit, since we rely on the execution environment to let us know if we run out of memory.

Details about heap activities are logged.

This facility should be helpful for those situations where memory resources are extremely constrained.