### PR TITLE
Fix deserialization of error codes

### DIFF
--- a/federation-2/harmonizer/src/js_types.rs
+++ b/federation-2/harmonizer/src/js_types.rs
@@ -22,7 +22,6 @@ pub(crate) struct CompositionError {
     /// A human-readable description of the error that prevented composition.
     message: Option<String>,
 
-    #[serde(flatten)]
     /// [`JsCompositionErrorExtensions`]
     extensions: Option<JsCompositionErrorExtensions>,
 }


### PR DESCRIPTION
The code for error coming from composition through harmonizer were not correctly handled, because when deserializing the JSON, the `code` was excepted at the top-level of the error object, while in practice it is within an `extensions` sub-object.

This seems like an oversight seems the error type itself has the `code` field with a sub-structure of the `extensions` field, and so it should deserialize correctly but wasn't because of a "rogue" `#[serde(flatten)]`. This commit thus simply remove that incorrect flattening.

Side-note: the patch only modify the federation 2 side. It could be a problem in the federation 1 side too, but I'm not entirely confident and would need to dig a bit. But also, users should just upgrade to federation 2 at this point, so if it's broken for federation 1 and only fixed in federation 2, that's probably just fine too anyway.