### PR TITLE
Install Volta w/ `cargo install` to overcome lack of Linux ARM binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,21 +263,25 @@ commands:
                   curl https://get.volta.sh | bash -s -- --skip-setup
                   echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
                   echo 'export PATH=$VOLTA_HOME/bin:$PATH' >> $BASH_ENV
-      
+
       - when:
           condition:
             equal: [ *arm_ubuntu_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Install volta
+                # The install script seems to fail with a message saying:
+                # Releases for non x64 architectures are not currently supported
+                # However, this is just a constraint of the pre-built binaries.
+                # Therefore, we just compile and install it and it's effectively
+                # the same, albeit quite a bit slower.  This may have been a
+                # regression in the installer script because I think this worked
+                # in the past.
                 command: |
                   VOLTA_VERSION=$(curl --silent "https://volta.sh/latest-version")
-                  git clone https://github.com/volta-cli/volta
+                  git clone https://github.com/volta-cli/volta --branch "v${VOLTA_VERSION}"
                   cd volta
-                  git checkout "v$VOLTA_VERSION"
-                  ./dev/unix/volta-install.sh --skip-setup --dev
-                  echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
-                  echo 'export PATH=$VOLTA_HOME/bin:$PATH' >> $BASH_ENV
+                  cargo install --path .
 
       - when:
           condition:


### PR DESCRIPTION
This aims to resolve a blocker encountered by @jeffjakub when trying to land https://github.com/apollographql/federation-rs/pull/202, which appears to be a new transient failure in `volta` and is preventing us from releasing Federation 2.1.4 in both `harmonizer` and `router-bridge`.  The error encountered there is:

```
Releases for non x64 architectures are not currently supported
```

Which is produced by the install script [here](https://github.com/volta-cli/volta/blob/main/dev/unix/volta-install.sh#L129-L136).

Since the Linux ARM binaries are not published and the install script seems to struggle with the request to install from source we need to just build in our more traditional ways using `cargo install`.

We may want to consider pinning the `volta` version if this continues to be problematic, but this should unblock us in the near term. (I did not bother bisecting if there was a previous version on which this worked.)