### PR TITLE
release: apollo-federation-types@v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "assert_fs",
  "camino",

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation-types"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 description = """

--- a/apollo-federation-types/RELEASE_CHECKLIST.md
+++ b/apollo-federation-types/RELEASE_CHECKLIST.md
@@ -14,7 +14,8 @@ None of the `federation-rs` packages currently maintain changelogs as they are l
 1. Run `PUBSLUG=apollo-federation-types@v{version}` where `{version}` is the new version you're bumping to.
 1. Run `git checkout main && git stash && git pull && git checkout -b $PUBSLUG`.
 1. Update the version of `apollo-federation-types` in `Cargo.toml`
-1. Run `cargo build -p apollo-federation-types` from the root of `federation-rs`
+1. Update the versions of `apollo-federation-types` in `./federation-1/harmonizer/Cargo.toml` and `./federation-2/harmonizer/Cargo.toml`
+1. Run `cargo xtask dist --debug` from the root of `federation-rs`
 1. Push up a commit containing the version bumps with the message `release: $PUBSLUG`
 1. Wait for tests to pass on the PR
 1. Merge your PR to `main`

--- a/federation-1/Cargo.lock
+++ b/federation-1/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-1/harmonizer/Cargo.toml
+++ b/federation-1/harmonizer/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.6", path = "../../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.7", path = "../../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.118.0"

--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-2/harmonizer/Cargo.toml
+++ b/federation-2/harmonizer/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.6", path = "../../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.7", path = "../../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.142.0"


### PR DESCRIPTION
releasing the latest changes so rover doesn't need to rely on a git hash (https://github.com/apollographql/rover/issues/1417)