### PR TITLE
chore: updates to latest-plugin

### DIFF
--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -30,7 +30,9 @@ impl PluginVersion for RouterVersion {
     fn get_tarball_version(&self) -> String {
         match self {
             Self::Exact(v) => format!("v{}", v),
-            Self::Latest => "latest".to_string(),
+            // the endpoint for getting router plugins via rover.apollo.dev 
+            // uses "latest-plugin" instead of "latest" zsto get the latest version
+            Self::Latest => "latest-plugin".to_string(),
         }
     }
 }


### PR DESCRIPTION
orbiter recently updated its behavior to provide a separate special version for the router `latest-plugin`. this pr updates that functionality in `apollo-federation-types`