### PR TITLE
chore: reverts last 6 commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.7.1"
+version = "0.7.0"
 dependencies = [
  "assert_fs",
  "camino",

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation-types"
-version = "0.7.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 description = """

--- a/federation-1/Cargo.lock
+++ b/federation-1/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.7.1"
+version = "0.7.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.7.1"
+version = "0.7.0"
 dependencies = [
  "camino",
  "log",


### PR DESCRIPTION
there was an issue with the most recent publishes due to a bad secret rotation. this PR reverts the last few commits to prepare for publishes with the correct permissions.