### PR TITLE
release: router-bridge@v0.1.13-beta+v2.3.0-beta.2

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1072,7 +1072,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "router-bridge"
-version = "0.1.13"
+version = "0.1.13-beta+v2.3.0-beta.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router-bridge"
-version = "0.1.13"
+version = "0.1.13-beta+v2.3.0-beta.2"
 authors = ["Apollo <packages@apollographql.com>"]
 edition = "2018"
 description = "JavaScript bridge for the Apollo Router"

--- a/federation-2/router-bridge/package-lock.json
+++ b/federation-2/router-bridge/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Elastic-2.0",
       "dependencies": {
         "@apollo/core-schema": "^0.3.0",
-        "@apollo/federation-internals": "^2.3.0-alpha.0",
-        "@apollo/query-planner": "^2.3.0-alpha.0",
+        "@apollo/federation-internals": "^2.3.0-beta.2",
+        "@apollo/query-planner": "^2.3.0-beta.2",
         "@apollo/utils.usagereporting": "^1.0.0",
         "apollo-reporting-protobuf": "^3.3.1",
         "fast-text-encoding": "1.0.3",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.3.0-alpha.0.tgz",
-      "integrity": "sha512-PltPQtwj1HsmtX7nbMYYmS0Ds162U9IFHr2mK7qTfIsKcM4ZEeJJnEqLBC6xyG46B5COd/0KwSMwurY4/GLNFQ==",
+      "version": "2.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.3.0-beta.2.tgz",
+      "integrity": "sha512-sLVu170yr6yDyxY37/Lziej5dogPGL9YrcpMqNHgse5jc7xOTz1WjMOhhMGlGfiWbI9eRXyx+RzwK6/nrO7p9g==",
       "dependencies": {
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
@@ -91,11 +91,11 @@
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.3.0-alpha.0.tgz",
-      "integrity": "sha512-v02Ibk2BVJCjkPoWlbKFgKUHUZHi/uo1xXjbynIWcEJzEMouGE9uHOL45xIEC0dtWePonD4AY3SO+uxd+dL1Ag==",
+      "version": "2.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.3.0-beta.2.tgz",
+      "integrity": "sha512-Iw2irAB+SglPge4oxbbh+psPrYErgjtZ36OQz2Ulvfkm9kz4+yJloMNpV+yA4BFL4y8+qubKnlN6wuGChFfEFg==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.3.0-alpha.0",
+        "@apollo/federation-internals": "2.3.0-beta.2",
         "@types/uuid": "^8.3.4",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0",
@@ -109,12 +109,12 @@
       }
     },
     "node_modules/@apollo/query-planner": {
-      "version": "2.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.3.0-alpha.0.tgz",
-      "integrity": "sha512-OKjA+scQmiFu8fhmLdjUFqQuXwcsKQRww6KWgSQ+upZipss0g1S9uLPR7DSn922wGfFIZ2/1CNT7w1OQ863WLg==",
+      "version": "2.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.3.0-beta.2.tgz",
+      "integrity": "sha512-TO1SMb/xgRxoAOoaF/RVRphF2S3F8bY/Wn8msGjz2yB+cDWJh1F5yaLZDPh2hBEMiuOTYN4wsj1DPvz1AihO3w==",
       "dependencies": {
-        "@apollo/federation-internals": "^2.3.0-alpha.0",
-        "@apollo/query-graphs": "^2.3.0-alpha.0",
+        "@apollo/federation-internals": "2.3.0-beta.2",
+        "@apollo/query-graphs": "2.3.0-beta.2",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
@@ -632,16 +632,18 @@
       }
     },
     "node_modules/deep-equal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
-      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-get-iterator": "^1.1.2",
         "get-intrinsic": "^1.1.3",
         "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
         "is-date-object": "^1.0.5",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
         "isarray": "^2.0.5",
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
@@ -650,7 +652,7 @@
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.8"
+        "which-typed-array": "^1.1.9"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1248,6 +1250,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1382,6 +1397,17 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2225,9 +2251,9 @@
       }
     },
     "@apollo/federation-internals": {
-      "version": "2.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.3.0-alpha.0.tgz",
-      "integrity": "sha512-PltPQtwj1HsmtX7nbMYYmS0Ds162U9IFHr2mK7qTfIsKcM4ZEeJJnEqLBC6xyG46B5COd/0KwSMwurY4/GLNFQ==",
+      "version": "2.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.3.0-beta.2.tgz",
+      "integrity": "sha512-sLVu170yr6yDyxY37/Lziej5dogPGL9YrcpMqNHgse5jc7xOTz1WjMOhhMGlGfiWbI9eRXyx+RzwK6/nrO7p9g==",
       "requires": {
         "chalk": "^4.1.0",
         "js-levenshtein": "^1.1.6"
@@ -2254,11 +2280,11 @@
       }
     },
     "@apollo/query-graphs": {
-      "version": "2.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.3.0-alpha.0.tgz",
-      "integrity": "sha512-v02Ibk2BVJCjkPoWlbKFgKUHUZHi/uo1xXjbynIWcEJzEMouGE9uHOL45xIEC0dtWePonD4AY3SO+uxd+dL1Ag==",
+      "version": "2.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.3.0-beta.2.tgz",
+      "integrity": "sha512-Iw2irAB+SglPge4oxbbh+psPrYErgjtZ36OQz2Ulvfkm9kz4+yJloMNpV+yA4BFL4y8+qubKnlN6wuGChFfEFg==",
       "requires": {
-        "@apollo/federation-internals": "^2.3.0-alpha.0",
+        "@apollo/federation-internals": "2.3.0-beta.2",
         "@types/uuid": "^8.3.4",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^0.16.0",
@@ -2266,12 +2292,12 @@
       }
     },
     "@apollo/query-planner": {
-      "version": "2.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.3.0-alpha.0.tgz",
-      "integrity": "sha512-OKjA+scQmiFu8fhmLdjUFqQuXwcsKQRww6KWgSQ+upZipss0g1S9uLPR7DSn922wGfFIZ2/1CNT7w1OQ863WLg==",
+      "version": "2.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@apollo/query-planner/-/query-planner-2.3.0-beta.2.tgz",
+      "integrity": "sha512-TO1SMb/xgRxoAOoaF/RVRphF2S3F8bY/Wn8msGjz2yB+cDWJh1F5yaLZDPh2hBEMiuOTYN4wsj1DPvz1AihO3w==",
       "requires": {
-        "@apollo/federation-internals": "^2.3.0-alpha.0",
-        "@apollo/query-graphs": "^2.3.0-alpha.0",
+        "@apollo/federation-internals": "2.3.0-beta.2",
+        "@apollo/query-graphs": "2.3.0-beta.2",
         "chalk": "^4.1.0",
         "deep-equal": "^2.0.5",
         "pretty-format": "^29.0.0"
@@ -2645,16 +2671,18 @@
       }
     },
     "deep-equal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.1.0.tgz",
-      "integrity": "sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-get-iterator": "^1.1.2",
         "get-intrinsic": "^1.1.3",
         "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
         "is-date-object": "^1.0.5",
         "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
         "isarray": "^2.0.5",
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
@@ -2663,7 +2691,7 @@
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.8"
+        "which-typed-array": "^1.1.9"
       }
     },
     "define-properties": {
@@ -3000,6 +3028,16 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3086,6 +3124,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-string": {
       "version": "1.0.7",

--- a/federation-2/router-bridge/package.json
+++ b/federation-2/router-bridge/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@apollo/core-schema": "^0.3.0",
-    "@apollo/federation-internals": "^2.3.0-alpha.0",
-    "@apollo/query-planner": "^2.3.0-alpha.0",
+    "@apollo/federation-internals": "^2.3.0-beta.2",
+    "@apollo/query-planner": "^2.3.0-beta.2",
     "@apollo/utils.usagereporting": "^1.0.0",
     "apollo-reporting-protobuf": "^3.3.1",
     "fast-text-encoding": "1.0.3",


### PR DESCRIPTION
For v2.3.0-beta.2

Using a little special version now to try it out as an experimental version number that also encodes the query planner version for sanity's clarity sake.
