### PR TITLE
release: router-bridge@v0.1.13-beta.0+v2.3.0-beta.3

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1081,7 +1081,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "router-bridge"
-version = "0.1.13-beta+v2.3.0-beta.3"
+version = "0.1.13-beta.0+v2.3.0-beta.3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router-bridge"
-version = "0.1.13-beta+v2.3.0-beta.3"
+version = "0.1.13-beta.0+v2.3.0-beta.3"
 authors = ["Apollo <packages@apollographql.com>"]
 edition = "2018"
 description = "JavaScript bridge for the Apollo Router"


### PR DESCRIPTION
Overall this is the same as the previous release of `0.1.13-beta`, just with `-beta.0` instead to resolve what might be a somewhat justifyable metadata ignore case. 
