### PR TITLE
reuse JsWorker instances

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "deno_core",
  "futures",
  "insta",
+ "once_cell",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -24,6 +24,7 @@ include = [
 anyhow = "1.0.44"
 async-channel = "1.6.1"
 deno_core = "0.167.0"
+once_cell = "1.16.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.68", features = ["preserve_order"] }
 thiserror = "1.0.30"


### PR DESCRIPTION
deno tends to leak data when creating a runtime, so by reusing a JsWorker instance, we would make sure that it only leaks once instead of on every schema change