### PR TITLE
updateable Planner

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "futures",
  "insta",
  "pretty_assertions",
+ "rand",
  "serde",
  "serde_json",
  "thiserror",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -24,6 +24,7 @@ include = [
 anyhow = "1.0.44"
 async-channel = "1.6.1"
 deno_core = "0.167.0"
+rand = "0.8.5"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.68", features = ["preserve_order"] }
 thiserror = "1.0.30"

--- a/federation-2/router-bridge/js-src/plan_worker.ts
+++ b/federation-2/router-bridge/js-src/plan_worker.ts
@@ -39,23 +39,28 @@ interface UpdateSchemaEvent {
   kind: PlannerEventKind.UpdateSchema;
   schema: string;
   config: QueryPlannerConfig;
+  schemaId: number;
 }
 interface PlanEvent {
   kind: PlannerEventKind.Plan;
   query: string;
   operationName?: string;
+  schemaId: number;
 }
 interface ApiSchemaEvent {
   kind: PlannerEventKind.ApiSchema;
+  schemaId: number;
 }
 
 interface IntrospectEvent {
   kind: PlannerEventKind.Introspect;
   query: string;
+  schemaId: number;
 }
 
 interface Exit {
   kind: PlannerEventKind.Exit;
+  schemaId: number;
 }
 type PlannerEvent =
   | UpdateSchemaEvent
@@ -164,14 +169,15 @@ const send = async (payload: WorkerResultWithId): Promise<void> => {
 const receive = async (): Promise<PlannerEventWithId> =>
   await Deno.core.ops.receive();
 
-let planner: BridgeQueryPlanner;
+let planners = new Map<number, BridgeQueryPlanner>();
 
 const updateQueryPlanner = (
   schema: string,
-  options: QueryPlannerConfig
+  options: QueryPlannerConfig,
+  schemaId: number
 ): WorkerResult => {
   try {
-    planner = new bridge.BridgeQueryPlanner(schema, options);
+    planners.set(schemaId, new bridge.BridgeQueryPlanner(schema, options));
     // This will be interpreted as a correct Update
     return {
       data: {
@@ -208,24 +214,37 @@ async function run() {
       try {
         switch (event?.kind) {
           case PlannerEventKind.UpdateSchema:
-            const updateResult = updateQueryPlanner(event.schema, event.config);
+            const updateResult = updateQueryPlanner(
+              event.schema,
+              event.config,
+              event.schemaId
+            );
             await send({ id, payload: updateResult });
             break;
           case PlannerEventKind.Plan:
-            const planResult = planner.plan(event.query, event.operationName);
+            const planResult = planners
+              .get(event.schemaId)
+              .plan(event.query, event.operationName);
             await send({ id, payload: planResult });
             break;
           case PlannerEventKind.ApiSchema:
-            const apiSchemaResult = planner.getApiSchema();
+            const apiSchemaResult = planners.get(event.schemaId).getApiSchema();
             const payload: ApiSchemaResult = { schema: apiSchemaResult };
             await send({ id, payload });
             break;
           case PlannerEventKind.Introspect:
-            const introspectResult = planner.introspect(event.query);
+            const introspectResult = planners
+              .get(event.schemaId)
+              .introspect(event.query);
             await send({ id, payload: introspectResult });
             break;
           case PlannerEventKind.Exit:
-            return;
+            planners.delete(event.schemaId);
+            if (planners.size == 0) {
+              return;
+            } else {
+              break;
+            }
           default:
             logger.warn(`unknown message received: ${JSON.stringify(event)}\n`);
             break;

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update-2.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update-2.snap
@@ -1,0 +1,204 @@
+---
+source: router-bridge/src/planner.rs
+expression: api_schema1.schema
+---
+directive @transform(from: String!) on FIELD
+
+union AccountType = PasswordAccount | SMSAccount
+
+type Amazon {
+  referrer: String
+}
+
+union Body = Image | Text
+
+type Book implements Product {
+  isbn: String!
+  title: String
+  year: Int
+  similarBooks: [Book]!
+  metadata: [MetadataOrError]
+  inStock: Boolean
+  isCheckedOut: Boolean
+  upc: String!
+  sku: String!
+  name(delimeter: String = " "): String
+  price: String
+  details: ProductDetailsBook
+  reviews: [Review]
+  relatedReviews: [Review!]!
+}
+
+union Brand = Ikea | Amazon
+
+type Car implements Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}
+
+type Error {
+  code: Int
+  message: String
+}
+
+type Furniture implements Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  brand: Brand
+  metadata: [MetadataOrError]
+  details: ProductDetailsFurniture
+  inStock: Boolean
+  isHeavy: Boolean
+  reviews: [Review]
+}
+
+type Ikea {
+  asile: Int
+}
+
+type Image implements NamedObject {
+  name: String!
+  attributes: ImageAttributes!
+}
+
+type ImageAttributes {
+  url: String!
+}
+
+type KeyValue {
+  key: String!
+  value: String!
+}
+
+type Library {
+  id: ID!
+  name: String
+  userAccount(id: ID! = 1): User
+}
+
+union MetadataOrError = KeyValue | Error
+
+type Mutation {
+  login(username: String!, password: String!): User
+  reviewProduct(upc: String!, body: String!): Product
+  updateReview(review: UpdateReviewInput!): Review
+  deleteReview(id: ID!): Boolean
+}
+
+type Name {
+  first: String
+  last: String
+}
+
+interface NamedObject {
+  name: String!
+}
+
+type PasswordAccount {
+  email: String!
+}
+
+interface Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  details: ProductDetails
+  inStock: Boolean
+  reviews: [Review]
+}
+
+interface ProductDetails {
+  country: String
+}
+
+type ProductDetailsBook implements ProductDetails {
+  country: String
+  pages: Int
+}
+
+type ProductDetailsFurniture implements ProductDetails {
+  country: String
+  color: String
+}
+
+type Query {
+  user(id: ID!): User
+  me: User
+  book(isbn: String!): Book
+  books: [Book]
+  library(id: ID!): Library
+  body: Body!
+  product(upc: String!): Product
+  vehicle(id: String!): Vehicle
+  topProducts(first: Int = 5): [Product]
+  topCars(first: Int = 5): [Car]
+  topReviews(first: Int = 5): [Review]
+}
+
+type Review {
+  id: ID!
+  author: User
+  product: Product
+  metadata: [MetadataOrError]
+}
+
+type SMSAccount {
+  number: String
+}
+
+type Text implements NamedObject {
+  name: String!
+  attributes: TextAttributes!
+}
+
+type TextAttributes {
+  bold: Boolean
+  text: String
+}
+
+union Thing = Car | Ikea
+
+input UpdateReviewInput {
+  id: ID!
+  body: String
+}
+
+type User {
+  id: ID!
+  name: Name
+  username: String
+  birthDate(locale: String): String
+  account: AccountType
+  metadata: [UserMetadata]
+  goodDescription: Boolean
+  vehicle: Vehicle
+  thing: Thing
+  reviews: [Review]
+  numberOfReviews: Int!
+  goodAddress: Boolean
+}
+
+type UserMetadata {
+  name: String
+  address: String
+  description: String
+}
+
+type Van implements Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}
+
+interface Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update-3.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update-3.snap
@@ -1,0 +1,83 @@
+---
+source: router-bridge/src/planner.rs
+expression: "serde_json::to_string_pretty(&query_plan2.data).unwrap()"
+---
+{
+  "queryPlan": {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Sequence",
+      "nodes": [
+        {
+          "kind": "Fetch",
+          "serviceName": "accounts",
+          "variableUsages": [],
+          "operation": "{me{__typename id name{first}}}",
+          "operationKind": "query"
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "me"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "reviews",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{reviews{id author{__typename id}body}}}}",
+            "operationKind": "query"
+          }
+        },
+        {
+          "kind": "Flatten",
+          "path": [
+            "me",
+            "reviews",
+            "@",
+            "author"
+          ],
+          "node": {
+            "kind": "Fetch",
+            "serviceName": "accounts",
+            "requires": [
+              {
+                "kind": "InlineFragment",
+                "typeCondition": "User",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "name": "__typename"
+                  },
+                  {
+                    "kind": "Field",
+                    "name": "id"
+                  }
+                ]
+              }
+            ],
+            "variableUsages": [],
+            "operation": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name{first}}}}",
+            "operationKind": "query"
+          }
+        }
+      ]
+    }
+  },
+  "formattedQueryPlan": "QueryPlan {\n  Sequence {\n    Fetch(service: \"accounts\") {\n      {\n        me {\n          __typename\n          id\n          name {\n            first\n          }\n        }\n      }\n    },\n    Flatten(path: \"me\") {\n      Fetch(service: \"reviews\") {\n        {\n          ... on User {\n            __typename\n            id\n          }\n        } =>\n        {\n          ... on User {\n            reviews {\n              id\n              author {\n                __typename\n                id\n              }\n              body\n            }\n          }\n        }\n      },\n    },\n    Flatten(path: \"me.reviews.@.author\") {\n      Fetch(service: \"accounts\") {\n        {\n          ... on User {\n            __typename\n            id\n          }\n        } =>\n        {\n          ... on User {\n            name {\n              first\n            }\n          }\n        }\n      },\n    },\n  },\n}"
+}

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update-4.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update-4.snap
@@ -1,0 +1,205 @@
+---
+source: router-bridge/src/planner.rs
+expression: api_schema2.schema
+---
+directive @transform(from: String!) on FIELD
+
+union AccountType = PasswordAccount | SMSAccount
+
+type Amazon {
+  referrer: String
+}
+
+union Body = Image | Text
+
+type Book implements Product {
+  isbn: String!
+  title: String
+  year: Int
+  similarBooks: [Book]!
+  metadata: [MetadataOrError]
+  inStock: Boolean
+  isCheckedOut: Boolean
+  upc: String!
+  sku: String!
+  name(delimeter: String = " "): String
+  price: String
+  details: ProductDetailsBook
+  reviews: [Review]
+  relatedReviews: [Review!]!
+}
+
+union Brand = Ikea | Amazon
+
+type Car implements Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}
+
+type Error {
+  code: Int
+  message: String
+}
+
+type Furniture implements Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  brand: Brand
+  metadata: [MetadataOrError]
+  details: ProductDetailsFurniture
+  inStock: Boolean
+  isHeavy: Boolean
+  reviews: [Review]
+}
+
+type Ikea {
+  asile: Int
+}
+
+type Image implements NamedObject {
+  name: String!
+  attributes: ImageAttributes!
+}
+
+type ImageAttributes {
+  url: String!
+}
+
+type KeyValue {
+  key: String!
+  value: String!
+}
+
+type Library {
+  id: ID!
+  name: String
+  userAccount(id: ID! = 1): User
+}
+
+union MetadataOrError = KeyValue | Error
+
+type Mutation {
+  login(username: String!, password: String!): User
+  reviewProduct(upc: String!, body: String!): Product
+  updateReview(review: UpdateReviewInput!): Review
+  deleteReview(id: ID!): Boolean
+}
+
+type Name {
+  first: String
+  last: String
+}
+
+interface NamedObject {
+  name: String!
+}
+
+type PasswordAccount {
+  email: String!
+}
+
+interface Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  details: ProductDetails
+  inStock: Boolean
+  reviews: [Review]
+}
+
+interface ProductDetails {
+  country: String
+}
+
+type ProductDetailsBook implements ProductDetails {
+  country: String
+  pages: Int
+}
+
+type ProductDetailsFurniture implements ProductDetails {
+  country: String
+  color: String
+}
+
+type Query {
+  user(id: ID!): User
+  me: User
+  book(isbn: String!): Book
+  books: [Book]
+  library(id: ID!): Library
+  body: Body!
+  product(upc: String!): Product
+  vehicle(id: String!): Vehicle
+  topProducts(first: Int = 5): [Product]
+  topCars(first: Int = 5): [Car]
+  topReviews(first: Int = 5): [Review]
+}
+
+type Review {
+  id: ID!
+  body(format: Boolean = false): String
+  author: User
+  product: Product
+  metadata: [MetadataOrError]
+}
+
+type SMSAccount {
+  number: String
+}
+
+type Text implements NamedObject {
+  name: String!
+  attributes: TextAttributes!
+}
+
+type TextAttributes {
+  bold: Boolean
+  text: String
+}
+
+union Thing = Car | Ikea
+
+input UpdateReviewInput {
+  id: ID!
+  body: String
+}
+
+type User {
+  id: ID!
+  name: Name
+  username: String
+  birthDate(locale: String): String
+  account: AccountType
+  metadata: [UserMetadata]
+  goodDescription: Boolean
+  vehicle: Vehicle
+  thing: Thing
+  reviews: [Review]
+  numberOfReviews: Int!
+  goodAddress: Boolean
+}
+
+type UserMetadata {
+  name: String
+  address: String
+  description: String
+}
+
+type Van implements Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}
+
+interface Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__planner_update.snap
@@ -1,0 +1,23 @@
+---
+source: router-bridge/src/planner.rs
+expression: "&format!(\"{query_plan1:#?}\")"
+---
+PlanErrors {
+    errors: [
+        PlanError {
+            message: Some(
+                "Cannot query field \"body\" on type \"Review\".",
+            ),
+            extensions: Some(
+                PlanErrorExtensions {
+                    code: "GRAPHQL_VALIDATION_FAILED",
+                    exception: None,
+                },
+            ),
+        },
+    ],
+    usage_reporting: UsageReporting {
+        stats_report_key: "## GraphQLValidationFailure\n",
+        referenced_fields_by_type: {},
+    },
+}

--- a/federation-2/router-bridge/src/testdata/schema_without_review_body.graphql
+++ b/federation-2/router-bridge/src/testdata/schema_without_review_body.graphql
@@ -1,0 +1,274 @@
+schema
+@core(feature: "https://specs.apollo.dev/core/v0.1")
+@core(feature: "https://specs.apollo.dev/join/v0.1") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+) on FIELD_DEFINITION
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @stream on FIELD
+
+directive @transform(from: String!) on FIELD
+
+union AccountType = PasswordAccount | SMSAccount
+
+type Amazon {
+  referrer: String
+}
+
+union Body = Image | Text
+
+type Book implements Product
+@join__owner(graph: BOOKS)
+@join__type(graph: BOOKS, key: "isbn")
+@join__type(graph: INVENTORY, key: "isbn")
+@join__type(graph: PRODUCT, key: "isbn")
+@join__type(graph: REVIEWS, key: "isbn") {
+  isbn: String! @join__field(graph: BOOKS)
+  title: String @join__field(graph: BOOKS)
+  year: Int @join__field(graph: BOOKS)
+  similarBooks: [Book]! @join__field(graph: BOOKS)
+  metadata: [MetadataOrError] @join__field(graph: BOOKS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  isCheckedOut: Boolean @join__field(graph: INVENTORY)
+  upc: String! @join__field(graph: PRODUCT)
+  sku: String! @join__field(graph: PRODUCT)
+  name(delimeter: String = " "): String
+  @join__field(graph: PRODUCT, requires: "title year")
+  price: String @join__field(graph: PRODUCT)
+  details: ProductDetailsBook @join__field(graph: PRODUCT)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  relatedReviews: [Review!]!
+  @join__field(graph: REVIEWS, requires: "similarBooks{isbn}")
+}
+
+union Brand = Ikea | Amazon
+
+type Car implements Vehicle
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id") {
+  id: String! @join__field(graph: PRODUCT)
+  description: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  retailPrice: String @join__field(graph: REVIEWS, requires: "price")
+}
+
+type Error {
+  code: Int
+  message: String
+}
+
+type Furniture implements Product
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "upc")
+@join__type(graph: PRODUCT, key: "sku")
+@join__type(graph: INVENTORY, key: "sku")
+@join__type(graph: REVIEWS, key: "upc") {
+  upc: String! @join__field(graph: PRODUCT)
+  sku: String! @join__field(graph: PRODUCT)
+  name: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  brand: Brand @join__field(graph: PRODUCT)
+  metadata: [MetadataOrError] @join__field(graph: PRODUCT)
+  details: ProductDetailsFurniture @join__field(graph: PRODUCT)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  isHeavy: Boolean @join__field(graph: INVENTORY)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Ikea {
+  asile: Int
+}
+
+type Image implements NamedObject {
+  name: String!
+  attributes: ImageAttributes!
+}
+
+type ImageAttributes {
+  url: String!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "")
+  BOOKS @join__graph(name: "books", url: "")
+  DOCUMENTS @join__graph(name: "documents", url: "")
+  INVENTORY @join__graph(name: "inventory", url: "")
+  PRODUCT @join__graph(name: "product", url: "")
+  REVIEWS @join__graph(name: "reviews", url: "")
+}
+
+type KeyValue {
+  key: String!
+  value: String!
+}
+
+type Library
+@join__owner(graph: BOOKS)
+@join__type(graph: BOOKS, key: "id")
+@join__type(graph: ACCOUNTS, key: "id") {
+  id: ID! @join__field(graph: BOOKS)
+  name: String @join__field(graph: BOOKS)
+  userAccount(id: ID! = 1): User @join__field(graph: ACCOUNTS, requires: "name")
+}
+
+union MetadataOrError = KeyValue | Error
+
+type Mutation {
+  login(username: String!, password: String!): User
+  @join__field(graph: ACCOUNTS)
+  reviewProduct(upc: String!, body: String!): Product
+  @join__field(graph: REVIEWS)
+  updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
+  deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
+}
+
+type Name {
+  first: String
+  last: String
+}
+
+interface NamedObject {
+  name: String!
+}
+
+type PasswordAccount
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "email") {
+  email: String! @join__field(graph: ACCOUNTS)
+}
+
+interface Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  details: ProductDetails
+  inStock: Boolean
+  reviews: [Review]
+}
+
+interface ProductDetails {
+  country: String
+}
+
+type ProductDetailsBook implements ProductDetails {
+  country: String
+  pages: Int
+}
+
+type ProductDetailsFurniture implements ProductDetails {
+  country: String
+  color: String
+}
+
+type Query {
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  me: User @join__field(graph: ACCOUNTS)
+  book(isbn: String!): Book @join__field(graph: BOOKS)
+  books: [Book] @join__field(graph: BOOKS)
+  library(id: ID!): Library @join__field(graph: BOOKS)
+  body: Body! @join__field(graph: DOCUMENTS)
+  product(upc: String!): Product @join__field(graph: PRODUCT)
+  vehicle(id: String!): Vehicle @join__field(graph: PRODUCT)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCT)
+  topCars(first: Int = 5): [Car] @join__field(graph: PRODUCT)
+  topReviews(first: Int = 5): [Review] @join__field(graph: REVIEWS)
+}
+
+type Review
+@join__owner(graph: REVIEWS)
+@join__type(graph: REVIEWS, key: "id") {
+  id: ID! @join__field(graph: REVIEWS)
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  product: Product @join__field(graph: REVIEWS)
+  metadata: [MetadataOrError] @join__field(graph: REVIEWS)
+}
+
+type SMSAccount
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "number") {
+  number: String @join__field(graph: ACCOUNTS)
+}
+
+type Text implements NamedObject {
+  name: String!
+  attributes: TextAttributes!
+}
+
+type TextAttributes {
+  bold: Boolean
+  text: String
+}
+
+union Thing = Car | Ikea
+
+input UpdateReviewInput {
+  id: ID!
+  body: String
+}
+
+type User
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "id")
+@join__type(graph: ACCOUNTS, key: "username name{first last}")
+@join__type(graph: INVENTORY, key: "id")
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id") {
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: Name @join__field(graph: ACCOUNTS)
+  username: String @join__field(graph: ACCOUNTS)
+  birthDate(locale: String): String @join__field(graph: ACCOUNTS)
+  account: AccountType @join__field(graph: ACCOUNTS)
+  metadata: [UserMetadata] @join__field(graph: ACCOUNTS)
+  goodDescription: Boolean
+  @join__field(graph: INVENTORY, requires: "metadata{description}")
+  vehicle: Vehicle @join__field(graph: PRODUCT)
+  thing: Thing @join__field(graph: PRODUCT)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  numberOfReviews: Int! @join__field(graph: REVIEWS)
+  goodAddress: Boolean
+  @join__field(graph: REVIEWS, requires: "metadata{address}")
+}
+
+type UserMetadata {
+  name: String
+  address: String
+  description: String
+}
+
+type Van implements Vehicle
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id") {
+  id: String! @join__field(graph: PRODUCT)
+  description: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  retailPrice: String @join__field(graph: REVIEWS, requires: "price")
+}
+
+interface Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}


### PR DESCRIPTION
Make the planner reusable by supporting schema changes in an existing JS runtime. Since the router might still be serving requests while we are creating a new router pipeline with a new schema, we must support multiple concurrent planners in the same runtime.

Here is how it works:
- when sending a schema to the JS side, we pass along a random schema id, created with the rust side `Planner` instance
- on every request from this `Planner`, the schema id will be sent
- when sending a new schema, we create a new `Planner` instance with the same `JsWorker` but a different schema id
- on the JS side, we have a map `schema id -> planner` so we know which planner to use for the request
- when a `Planner` is dropped, it still sends an `Exit` message, but with its schema id. On the JS side, we remove the corresponding planner from the map. If the map is empty, we stop the task