### PR TITLE
release: router-bridge@v0.2.0+v2.4.0

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.1.21+v2.4.0"
+version = "0.2.0+v2.4.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router-bridge"
-version = "0.1.21+v2.4.0"
+version = "0.2.0+v2.4.0"
 authors = ["Apollo <packages@apollographql.com>"]
 edition = "2018"
 description = "JavaScript bridge for the Apollo Router"


### PR DESCRIPTION
Re-releasing `router-bridge` with Fed v2.4.0 after https://github.com/apollographql/federation-rs/pull/281 fixed its broken state.

Also releasing this with a semver minor release, which I think aligns more clearly with the minor bump of Federation as well and clearly indicates the "new functionality" aspect of the minor position in the version.
