### PR TITLE
feat: Add `introspection_headers` to subgraph config for Rover feature

### DIFF
--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -35,3 +35,4 @@ serde_json = { version = "1", optional = true }
 [dev-dependencies]
 assert_fs = "1"
 serde_json = "1"
+serde_yaml = "0.8"

--- a/apollo-federation-types/src/config/subgraph.rs
+++ b/apollo-federation-types/src/config/subgraph.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use url::Url;
 
 /// Config for a single [subgraph](https://www.apollographql.com/docs/federation/subgraphs/)
@@ -39,25 +39,34 @@ impl SubgraphConfig {
 // in the configuration.
 #[serde(untagged)]
 pub enum SchemaSource {
-    File { file: Utf8PathBuf },
+    File {
+        file: Utf8PathBuf,
+    },
     SubgraphIntrospection {
         subgraph_url: Url,
-        introspection_headers: Option<HashMap<String, String>>
+        introspection_headers: Option<HashMap<String, String>>,
     },
-    Subgraph { graphref: String, subgraph: String },
-    Sdl { sdl: String },
+    Subgraph {
+        graphref: String,
+        subgraph: String,
+    },
+    Sdl {
+        sdl: String,
+    },
 }
 
 #[cfg(test)]
 mod test_schema_source {
-    use serde_yaml::from_str;
     use crate::config::SchemaSource;
+    use serde_yaml::from_str;
 
     #[test]
     fn test_file() {
         let yaml = "file: some/path.thing";
         let source: SchemaSource = from_str(yaml).unwrap();
-        let expected = SchemaSource::File {file: "some/path.thing".into()};
+        let expected = SchemaSource::File {
+            file: "some/path.thing".into(),
+        };
         assert_eq!(source, expected);
     }
 
@@ -67,7 +76,7 @@ mod test_schema_source {
         let source: SchemaSource = from_str(yaml).unwrap();
         let expected = SchemaSource::SubgraphIntrospection {
             subgraph_url: "https://example.com/graphql".parse().unwrap(),
-            introspection_headers: None
+            introspection_headers: None,
         };
         assert_eq!(source, expected);
     }
@@ -81,10 +90,13 @@ introspection_headers:
     "#;
         let source: SchemaSource = from_str(yaml).unwrap();
         let mut expected_headers = std::collections::HashMap::new();
-        expected_headers.insert("Router-Authorization".to_string(), "${env.HELLO_TESTS}".to_string());
+        expected_headers.insert(
+            "Router-Authorization".to_string(),
+            "${env.HELLO_TESTS}".to_string(),
+        );
         let expected = SchemaSource::SubgraphIntrospection {
             subgraph_url: "https://example.com/graphql".parse().unwrap(),
-            introspection_headers: Some(expected_headers)
+            introspection_headers: Some(expected_headers),
         };
         assert_eq!(source, expected);
     }
@@ -98,7 +110,7 @@ subgraph: my-subgraph
         let source: SchemaSource = from_str(yaml).unwrap();
         let expected = SchemaSource::Subgraph {
             graphref: "my-graph@current".to_string(),
-            subgraph: "my-subgraph".to_string()
+            subgraph: "my-subgraph".to_string(),
         };
         assert_eq!(source, expected);
     }
@@ -112,7 +124,7 @@ sdl: |
     }"#;
         let source: SchemaSource = from_str(yaml).unwrap();
         let expected = SchemaSource::Sdl {
-            sdl: "type Query {\n    hello: String\n}".to_string()
+            sdl: "type Query {\n    hello: String\n}".to_string(),
         };
         assert_eq!(source, expected);
     }

--- a/apollo-federation-types/src/config/subgraph.rs
+++ b/apollo-federation-types/src/config/subgraph.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -32,14 +33,87 @@ impl SubgraphConfig {
 ///
 /// NOTE: Introspection strips all comments and directives
 /// from the SDL.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 // this is untagged, meaning its fields will be flattened into the parent
 // struct when de/serialized. There is no top level `schema_source`
 // in the configuration.
 #[serde(untagged)]
 pub enum SchemaSource {
     File { file: Utf8PathBuf },
-    SubgraphIntrospection { subgraph_url: Url },
+    SubgraphIntrospection {
+        subgraph_url: Url,
+        introspection_headers: Option<HashMap<String, String>>
+    },
     Subgraph { graphref: String, subgraph: String },
     Sdl { sdl: String },
+}
+
+#[cfg(test)]
+mod test_schema_source {
+    use serde_yaml::from_str;
+    use crate::config::SchemaSource;
+
+    #[test]
+    fn test_file() {
+        let yaml = "file: some/path.thing";
+        let source: SchemaSource = from_str(yaml).unwrap();
+        let expected = SchemaSource::File {file: "some/path.thing".into()};
+        assert_eq!(source, expected);
+    }
+
+    #[test]
+    fn test_subgraph_introspection_no_headers() {
+        let yaml = "subgraph_url: https://example.com/graphql";
+        let source: SchemaSource = from_str(yaml).unwrap();
+        let expected = SchemaSource::SubgraphIntrospection {
+            subgraph_url: "https://example.com/graphql".parse().unwrap(),
+            introspection_headers: None
+        };
+        assert_eq!(source, expected);
+    }
+
+    #[test]
+    fn test_subgraph_introspection_with_headers() {
+        let yaml = r#"
+subgraph_url: https://example.com/graphql
+introspection_headers:
+    Router-Authorization: ${env.HELLO_TESTS}
+    "#;
+        let source: SchemaSource = from_str(yaml).unwrap();
+        let mut expected_headers = std::collections::HashMap::new();
+        expected_headers.insert("Router-Authorization".to_string(), "${env.HELLO_TESTS}".to_string());
+        let expected = SchemaSource::SubgraphIntrospection {
+            subgraph_url: "https://example.com/graphql".parse().unwrap(),
+            introspection_headers: Some(expected_headers)
+        };
+        assert_eq!(source, expected);
+    }
+
+    #[test]
+    fn test_subgraph() {
+        let yaml = r#"
+graphref: my-graph@current
+subgraph: my-subgraph
+        "#;
+        let source: SchemaSource = from_str(yaml).unwrap();
+        let expected = SchemaSource::Subgraph {
+            graphref: "my-graph@current".to_string(),
+            subgraph: "my-subgraph".to_string()
+        };
+        assert_eq!(source, expected);
+    }
+
+    #[test]
+    fn test_sdl() {
+        let yaml = r#"
+sdl: |
+    type Query {
+        hello: String
+    }"#;
+        let source: SchemaSource = from_str(yaml).unwrap();
+        let expected = SchemaSource::Sdl {
+            sdl: "type Query {\n    hello: String\n}".to_string()
+        };
+        assert_eq!(source, expected);
+    }
 }


### PR DESCRIPTION
Supports https://github.com/apollographql/rover/issues/615

BREAKING CHANGE:  A new field was added to SchemaSource::SubgraphIntrospection which is not `#[non_exhaustive]`

Also added some local unit tests for that enum.