### PR TITLE
chore: dont require openssl locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,8 +217,8 @@ commands:
                 name: Install development tools
                 command: yum groupinstall -y "Development Tools"
             - run:
-                name: Install gcc and OpenSSL
-                command: yum -y install perl-core gcc openssl-devel openssl
+                name: Install gcc
+                command: yum -y install perl-core gcc
             - run:
                 name: Check glibc version
                 command: ldd --version
@@ -242,7 +242,7 @@ commands:
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
-          
+
       - install_volta:
           platform: << parameters.platform >>
 

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -1,6 +1,3 @@
-use anyhow::anyhow;
-use camino::Utf8Path;
-
 use std::{collections::HashMap, fmt, str::FromStr};
 
 use crate::Result;
@@ -9,7 +6,6 @@ pub(crate) const TARGET_LINUX_UNKNOWN_GNU: &str = "x86_64-unknown-linux-gnu";
 pub(crate) const TARGET_LINUX_ARM: &str = "aarch64-unknown-linux-gnu";
 pub(crate) const TARGET_WINDOWS_MSVC: &str = "x86_64-pc-windows-msvc";
 pub(crate) const TARGET_MACOS_AMD64: &str = "x86_64-apple-darwin";
-const BREW_OPT: &[&str] = &["/usr/local/opt", "/opt/homebrew/Cellar"];
 
 pub(crate) const POSSIBLE_TARGETS: [&str; 4] = [
     TARGET_LINUX_UNKNOWN_GNU,
@@ -41,10 +37,12 @@ impl Target {
         Self::Other == *self
     }
 
+    #[allow(unused)]
     pub(crate) fn is_macos(&self) -> bool {
         Self::MacOSAmd64 == *self
     }
 
+    #[allow(unused)]
     pub(crate) fn is_linux(&self) -> bool {
         Self::LinuxAarch64 == *self || Self::LinuxUnknownGnu == *self
     }

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -55,23 +55,7 @@ impl Target {
 
     pub(crate) fn get_env(&self) -> Result<HashMap<String, String>> {
         let mut env = HashMap::new();
-        if self.is_linux() {
-            env.insert("OPENSSL_STATIC".to_string(), "1".to_string());
-        } else if self.is_macos() {
-            let openssl_path = BREW_OPT
-                .iter()
-                .map(|x| Utf8Path::new(x).join("openssl@1.1"))
-                .find(|x| x.exists())
-                .ok_or_else(|| {
-                    anyhow!(
-                        "OpenSSL v1.1 is not installed. Please install with `brew install \
-                    openssl@1.1`"
-                    )
-                })?;
-
-            env.insert("OPENSSL_ROOT_DIR".to_string(), openssl_path.to_string());
-            env.insert("OPENSSL_STATIC".to_string(), "1".to_string());
-        } else if self.is_windows() {
+        if self.is_windows() {
             env.insert(
                 "RUSTFLAGS".to_string(),
                 "-Ctarget-feature=+crt-static".to_string(),


### PR DESCRIPTION
fixes #320

`xtask` sets some openssl variables to statically build openssl. this was cargo culted from rover, nothing actually uses `openssl` in this repository, meaning it is unnecessary extra overhead. this PR removes the openssl env vars and the steps in CI that install openssl.