### PR TITLE
Bump CCI cache buster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,14 +365,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
 
       - run:
           command: cargo xtask << parameters.command >> << parameters.options >>
           working_directory: << parameters.working_directory >>
 
       - save_cache:
-          key: rust-target-v1-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
           paths:
             - target/
 


### PR DESCRIPTION
Hoping to resolve a failed publish, possibly caused by a stale cache in CI. This bumps the cache version to ensure a clean build.

Most recently failed job:
https://app.circleci.com/pipelines/github/apollographql/federation-rs/1591/workflows/aa633fef-29a1-4acb-adb3-f6841a78dd90/jobs/7281

Follow up for this PR is to run `cargo xtask tag` to move/push the correct tags to `main`'s HEAD and trigger the release.