### PR TITLE
release: apollo-federation-types@v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "assert_fs",
  "camino",

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-federation-types"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 description = """

--- a/federation-1/Cargo.lock
+++ b/federation-1/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-1/harmonizer/Cargo.toml
+++ b/federation-1/harmonizer/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.8", path = "../../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.9", path = "../../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.167.0"

--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "camino",
  "log",

--- a/federation-2/harmonizer/Cargo.toml
+++ b/federation-2/harmonizer/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.8", path = "../../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.9", path = "../../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.187.0"


### PR DESCRIPTION
This release adds some extra types for including source information alongside errors.