### PR TITLE
Forward BuildError.nodes, BuildHint.code, BuildHint.nodes to get better error messages

### DIFF
--- a/apollo-federation-types/src/build/error.rs
+++ b/apollo-federation-types/src/build/error.rs
@@ -33,6 +33,24 @@ pub struct BuildErrorNode {
     end: Option<BuildErrorNodeLocationToken>,
 }
 
+impl BuildErrorNode {
+    pub fn get_subgraph(&self) -> Option<String> {
+        self.subgraph.clone()
+    }
+
+    pub fn get_source(&self) -> Option<String> {
+        self.source.clone()
+    }
+
+    pub fn get_start(&self) -> Option<BuildErrorNodeLocationToken> {
+        self.start.clone()
+    }
+
+    pub fn get_end(&self) -> Option<BuildErrorNodeLocationToken> {
+        self.end.clone()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BuildErrorNodeLocation {
     subgraph: Option<String>,
@@ -44,6 +62,24 @@ pub struct BuildErrorNodeLocationToken {
     end: Option<u32>,
     column: Option<u32>,
     line: Option<u32>,
+}
+
+impl BuildErrorNodeLocationToken {
+    pub fn get_start(&self) -> Option<u32> {
+        self.start
+    }
+
+    pub fn get_end(&self) -> Option<u32> {
+        self.end
+    }
+
+    pub fn get_column(&self) -> Option<u32> {
+        self.column
+    }
+
+    pub fn get_line(&self) -> Option<u32> {
+        self.line
+    }
 }
 
 impl BuildError {
@@ -89,6 +125,10 @@ impl BuildError {
 
     pub fn get_type(&self) -> BuildErrorType {
         self.r#type.clone()
+    }
+
+    pub fn get_nodes(&self) -> Option<Vec<BuildErrorNode>> {
+        self.nodes.clone()
     }
 }
 

--- a/apollo-federation-types/src/build/hint.rs
+++ b/apollo-federation-types/src/build/hint.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use crate::build::BuildErrorNode;
+use serde::{Deserialize, Serialize};
 
 /// BuildHint contains helpful information that pertains to a build
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -18,7 +18,7 @@ pub struct BuildHint {
 }
 
 impl BuildHint {
-    pub fn new(message: String, code: String, nodes: Option<Vec<BuildErrorNode>>,) -> Self {
+    pub fn new(message: String, code: String, nodes: Option<Vec<BuildErrorNode>>) -> Self {
         Self {
             message,
             code,
@@ -47,7 +47,10 @@ mod tests {
     fn it_can_deserialize() {
         let msg = "hint".to_string();
         let code = "hintCode".to_string();
-        let actual_struct = serde_json::from_str(&json!({ "message": &msg, "code": &code, "nodes": null }).to_string()).unwrap();
+        let actual_struct = serde_json::from_str(
+            &json!({ "message": &msg, "code": &code, "nodes": null }).to_string(),
+        )
+        .unwrap();
         let expected_struct = BuildHint::new(msg, code, None);
         assert_eq!(expected_struct, actual_struct);
     }
@@ -59,7 +62,8 @@ mod tests {
         let unexpected_key = "this-would-never-happen".to_string();
         let unexpected_value = "but-maybe-something-else-more-reasonable-would".to_string();
         let actual_struct = serde_json::from_str(
-            &json!({ "message": &msg, "code": &code, &unexpected_key: &unexpected_value }).to_string(),
+            &json!({ "message": &msg, "code": &code, &unexpected_key: &unexpected_value })
+                .to_string(),
         )
         .unwrap();
         let mut expected_struct = BuildHint::new(msg, code, None);

--- a/apollo-federation-types/src/build/hint.rs
+++ b/apollo-federation-types/src/build/hint.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use crate::build::BuildErrorNode;
 
 /// BuildHint contains helpful information that pertains to a build
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -6,15 +7,22 @@ pub struct BuildHint {
     /// The message of the hint
     pub message: String,
 
+    /// The code of the hint
+    pub code: String,
+
+    pub nodes: Option<Vec<BuildErrorNode>>,
+
     /// Other untyped JSON included in the build hint.
     #[serde(flatten)]
     pub other: crate::UncaughtJson,
 }
 
 impl BuildHint {
-    pub fn new(message: String) -> Self {
+    pub fn new(message: String, code: String, nodes: Option<Vec<BuildErrorNode>>,) -> Self {
         Self {
             message,
+            code,
+            nodes,
             other: crate::UncaughtJson::new(),
         }
     }
@@ -29,29 +37,32 @@ mod tests {
     #[test]
     fn it_can_serialize() {
         let msg = "hint".to_string();
-        let expected_json = json!({ "message": &msg });
-        let actual_json = serde_json::to_value(&BuildHint::new(msg)).unwrap();
+        let code = "hintCode".to_string();
+        let expected_json = json!({ "message": &msg, "code": &code });
+        let actual_json = serde_json::to_value(&BuildHint::new(msg, code, None)).unwrap();
         assert_eq!(expected_json, actual_json)
     }
 
     #[test]
     fn it_can_deserialize() {
         let msg = "hint".to_string();
-        let actual_struct = serde_json::from_str(&json!({ "message": &msg }).to_string()).unwrap();
-        let expected_struct = BuildHint::new(msg);
+        let code = "hintCode".to_string();
+        let actual_struct = serde_json::from_str(&json!({ "message": &msg, "code": &code }).to_string()).unwrap();
+        let expected_struct = BuildHint::new(msg, code, None);
         assert_eq!(expected_struct, actual_struct);
     }
 
     #[test]
     fn it_can_deserialize_even_with_unknown_fields() {
         let msg = "hint".to_string();
+        let code = "hintCode".to_string();
         let unexpected_key = "this-would-never-happen".to_string();
         let unexpected_value = "but-maybe-something-else-more-reasonable-would".to_string();
         let actual_struct = serde_json::from_str(
-            &json!({ "message": &msg, &unexpected_key: &unexpected_value }).to_string(),
+            &json!({ "message": &msg, "code": &code, &unexpected_key: &unexpected_value }).to_string(),
         )
         .unwrap();
-        let mut expected_struct = BuildHint::new(msg);
+        let mut expected_struct = BuildHint::new(msg, code, None);
         expected_struct
             .other
             .insert(unexpected_key, Value::String(unexpected_value));

--- a/apollo-federation-types/src/build/hint.rs
+++ b/apollo-federation-types/src/build/hint.rs
@@ -38,7 +38,7 @@ mod tests {
     fn it_can_serialize() {
         let msg = "hint".to_string();
         let code = "hintCode".to_string();
-        let expected_json = json!({ "message": &msg, "code": &code });
+        let expected_json = json!({ "message": &msg, "code": &code, "nodes": null });
         let actual_json = serde_json::to_value(&BuildHint::new(msg, code, None)).unwrap();
         assert_eq!(expected_json, actual_json)
     }
@@ -47,7 +47,7 @@ mod tests {
     fn it_can_deserialize() {
         let msg = "hint".to_string();
         let code = "hintCode".to_string();
-        let actual_struct = serde_json::from_str(&json!({ "message": &msg, "code": &code }).to_string()).unwrap();
+        let actual_struct = serde_json::from_str(&json!({ "message": &msg, "code": &code, "nodes": null }).to_string()).unwrap();
         let expected_struct = BuildHint::new(msg, code, None);
         assert_eq!(expected_struct, actual_struct);
     }

--- a/apollo-federation-types/src/build/mod.rs
+++ b/apollo-federation-types/src/build/mod.rs
@@ -5,7 +5,7 @@ mod subgraph_definition;
 
 /// The type representing the result of a supergraph build (for any version)
 pub type BuildResult = std::result::Result<BuildOutput, BuildErrors>;
-pub use error::{BuildError, BuildErrorNode, BuildErrorType, BuildErrors};
+pub use error::{BuildError, BuildErrorNode, BuildErrorType, BuildErrors, BuildErrorNodeLocationToken};
 pub use hint::BuildHint;
 pub use output::BuildOutput;
 pub use subgraph_definition::SubgraphDefinition;

--- a/apollo-federation-types/src/build/mod.rs
+++ b/apollo-federation-types/src/build/mod.rs
@@ -5,7 +5,9 @@ mod subgraph_definition;
 
 /// The type representing the result of a supergraph build (for any version)
 pub type BuildResult = std::result::Result<BuildOutput, BuildErrors>;
-pub use error::{BuildError, BuildErrorNode, BuildErrorType, BuildErrors, BuildErrorNodeLocationToken};
+pub use error::{
+    BuildError, BuildErrorNode, BuildErrorNodeLocationToken, BuildErrorType, BuildErrors,
+};
 pub use hint::BuildHint;
 pub use output::BuildOutput;
 pub use subgraph_definition::SubgraphDefinition;

--- a/apollo-federation-types/src/build/output.rs
+++ b/apollo-federation-types/src/build/output.rs
@@ -52,10 +52,12 @@ mod tests {
         let sdl = "my-sdl".to_string();
         let hint_one = "hint-one".to_string();
         let hint_two = "hint-two".to_string();
-        let expected_json = json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one}, {"message": &hint_two}]});
+        let code = "code".to_string();
+        let code2 = "code2".to_string();
+        let expected_json = json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one, "code": &code, "nodes": null}, {"message": &hint_two, "code": &code2, "nodes": null}]});
         let actual_json = serde_json::to_value(&BuildOutput::new_with_hints(
             sdl.to_string(),
-            vec![BuildHint::new(hint_one), BuildHint::new(hint_two)],
+            vec![BuildHint::new(hint_one, code, None), BuildHint::new(hint_two, code2, None)],
         ))
         .unwrap();
         assert_eq!(expected_json, actual_json)
@@ -76,12 +78,14 @@ mod tests {
         let sdl = "my-sdl".to_string();
         let hint_one = "hint-one".to_string();
         let hint_two = "hint-two".to_string();
+        let code = "code".to_string();
+        let code2 = "code2".to_string();
         let actual_struct =
-            serde_json::from_str(&json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one}, {"message": &hint_two}]}).to_string())
+            serde_json::from_str(&json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one, "code": &code}, {"message": &hint_two, "code": &code2}]}).to_string())
                 .unwrap();
         let expected_struct = BuildOutput::new_with_hints(
             sdl,
-            vec![BuildHint::new(hint_one), BuildHint::new(hint_two)],
+            vec![BuildHint::new(hint_one, code, None), BuildHint::new(hint_two, code2, None)],
         );
 
         assert_eq!(expected_struct, actual_struct)

--- a/apollo-federation-types/src/build/output.rs
+++ b/apollo-federation-types/src/build/output.rs
@@ -57,7 +57,10 @@ mod tests {
         let expected_json = json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one, "code": &code, "nodes": null}, {"message": &hint_two, "code": &code2, "nodes": null}]});
         let actual_json = serde_json::to_value(&BuildOutput::new_with_hints(
             sdl.to_string(),
-            vec![BuildHint::new(hint_one, code, None), BuildHint::new(hint_two, code2, None)],
+            vec![
+                BuildHint::new(hint_one, code, None),
+                BuildHint::new(hint_two, code2, None),
+            ],
         ))
         .unwrap();
         assert_eq!(expected_json, actual_json)
@@ -85,7 +88,10 @@ mod tests {
                 .unwrap();
         let expected_struct = BuildOutput::new_with_hints(
             sdl,
-            vec![BuildHint::new(hint_one, code, None), BuildHint::new(hint_two, code2, None)],
+            vec![
+                BuildHint::new(hint_one, code, None),
+                BuildHint::new(hint_two, code2, None),
+            ],
         );
 
         assert_eq!(expected_struct, actual_struct)

--- a/federation-2/harmonizer/js-src/composition.ts
+++ b/federation-2/harmonizer/js-src/composition.ts
@@ -1,5 +1,5 @@
 import { composeServices } from "@apollo/composition";
-import { parse, Token } from "graphql";
+import { ASTNode, GraphQLError, parse, Token } from "graphql";
 import {
   BuildErrorNode,
   CompositionError,
@@ -7,6 +7,7 @@ import {
   CompositionResult,
   Position,
 } from "./types";
+import { ERRORS } from "@apollo/federation-internals";
 
 export function composition(
   serviceList: { sdl: string; name: string; url?: string }[]
@@ -26,8 +27,9 @@ export function composition(
     }
   });
 
-  let subgraphList = serviceList.map(({ sdl, ...rest }) => ({
-    typeDefs: parseTypedefs(sdl),
+  let subgraphList = serviceList.map(({ sdl, name, ...rest }) => ({
+    typeDefs: parseTypedefs(sdl, name),
+    name,
     ...rest,
   }));
 
@@ -36,7 +38,7 @@ export function composition(
   if (composed.hints) {
     composed.hints.map((composed_hint) => {
       let nodes: BuildErrorNode[] = [];
-      composed_hint.nodes.map((node) => {
+      composed_hint.nodes?.map((node) => {
         nodes.push({
           subgraph: (node as any)?.subgraph,
           source: node?.loc.source.body,
@@ -58,7 +60,7 @@ export function composition(
     let errors: CompositionError[] = [];
     composed.errors.map((err) => {
       let nodes: BuildErrorNode[] = [];
-      err.nodes.map((node) => {
+      err.nodes?.map((node) => {
         nodes.push({
           subgraph: (node as any)?.subgraph,
           source: node?.loc.source.body,
@@ -94,11 +96,39 @@ function getPosition(token: Token): Position {
 }
 
 //@ts-ignore
-function parseTypedefs(source: string) {
+function parseTypedefs(source: string, subgraphName: string) {
   try {
     return parse(source);
   } catch (err) {
+    let nodeTokens: BuildErrorNode[] = [];
+    if (err instanceof GraphQLError) {
+      nodeTokens =
+        err.nodes != null
+          ? err.nodes.map(function (n: ASTNode) {
+              return {
+                subgraph: subgraphName,
+                source: source,
+                start: getPosition(n.loc.startToken),
+                end: getPosition(n.loc.endToken),
+              };
+            })
+          : [
+              {
+                subgraph: subgraphName,
+                source: source,
+              },
+            ];
+    }
+
     // Return the error in a way that we know how to handle it.
-    done({ Err: [{ message: err.toString() }] });
+    done({
+      Err: [
+        {
+          code: ERRORS.INVALID_GRAPHQL.code,
+          message: "[" + subgraphName + "] - " + err.toString(),
+          nodes: nodeTokens,
+        },
+      ],
+    });
   }
 }

--- a/federation-2/harmonizer/js-src/types.ts
+++ b/federation-2/harmonizer/js-src/types.ts
@@ -21,3 +21,9 @@ export type Position = {
   line: number;
   column: number;
 };
+
+export type CompositionHint = {
+  message: string;
+  code: string;
+  nodes: BuildErrorNode[];
+};


### PR DESCRIPTION
This allows us retrieving the `code` and `subgraph` attributes when composition errors or hints are returned.

Also, in case a subgraph SDL is not syntactically valid, it used to bail just with the error message but no hint for which subgraph it occurred for. I modified the logic to return a true CompositionError.

