### PR TITLE
ci: Install volta from lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ commands:
                   VOLTA_VERSION=$(curl --silent "https://volta.sh/latest-version")
                   git clone https://github.com/volta-cli/volta --branch "v${VOLTA_VERSION}"
                   cd volta
-                  cargo install --path .
+                  cargo install --path . --locked
 
       - when:
           condition:


### PR DESCRIPTION
[Volta install fails for arm Ubuntu](https://app.circleci.com/pipelines/github/apollographql/federation-rs/1859/workflows/c28ac5bf-bbbb-4186-86d4-9862b75e64ed/jobs/8236) because:

1. Their rust-toolchain sets Rust to 1.63
2. Hashbrown 0.14.0 is allowed by their Cargo.toml
3. Hashbrown 0.14.0 MSRV is 1.64

I think just using the lock file should fix this