### PR TITLE
chore: make code optional to maintain backwards compatibility

### DIFF
--- a/apollo-federation-types/src/build/hint.rs
+++ b/apollo-federation-types/src/build/hint.rs
@@ -2,13 +2,15 @@ use crate::build::BuildErrorNode;
 use serde::{Deserialize, Serialize};
 
 /// BuildHint contains helpful information that pertains to a build
+/// New fields added to this struct must be optional in order to maintain
+/// backwards compatibility with old versions of Rover.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct BuildHint {
     /// The message of the hint
     pub message: String,
 
-    /// The code of the hint
-    pub code: String,
+    /// The code of the hint, this is an Option to maintain backwards compatibility.
+    pub code: Option<String>,
 
     pub nodes: Option<Vec<BuildErrorNode>>,
 
@@ -21,7 +23,7 @@ impl BuildHint {
     pub fn new(message: String, code: String, nodes: Option<Vec<BuildErrorNode>>) -> Self {
         Self {
             message,
-            code,
+            code: Some(code),
             nodes,
             other: crate::UncaughtJson::new(),
         }

--- a/apollo-federation-types/src/build/output.rs
+++ b/apollo-federation-types/src/build/output.rs
@@ -3,6 +3,8 @@ use crate::build::BuildHint;
 use serde::{Deserialize, Serialize};
 
 /// BuildOutput contains information about the supergraph that was composed.
+/// New fields added to this struct must be optional in order to maintain
+/// backwards compatibility with old versions of Rover.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildOutput {


### PR DESCRIPTION
rover uses `apollo-federation-types` to read the messages from black box composition plugins. recently a new `code` field was added to the `BuildHint` struct, which is great! unfortunately, introducing it as a `String` instead of an `Option<String>` was a backwards incompatible change. all fields added to `BuildOutput` must be optional in order to maintains backwards compatibility. i've added some comments to this effect.