### PR TITLE
Add build plugin types to federation-rs

### DIFF
--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -11,9 +11,10 @@ repository = "https://github.com/apollographql/federation-rs/"
 version = "0.9.2"
 
 [features]
-default = ["config", "build"]
+default = ["config", "build", "build_plugin"]
 
 build = ["serde_json"]
+build_plugin = ["serde_json"]
 config = ["camino", "log", "thiserror", "serde_yaml", "url", "serde_with"]
 
 [dependencies]

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "apollo-federation-types"
-version = "0.9.2"
-edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
 description = """
 apollo-federation-types contains types used by plugins for the Rover CLI
 """
+edition = "2021"
 license = "MIT"
+name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
+version = "0.9.2"
 
 [features]
 default = ["config", "build"]
@@ -18,19 +18,19 @@ config = ["camino", "log", "thiserror", "serde_yaml", "url", "serde_with"]
 
 [dependencies]
 # config and build dependencies
-serde = { version = "1", features = ["derive"] }
+serde = {version = "1", features = ["derive"]}
 
 # config-only dependencies
-camino = { version = "1", features = [ "serde1" ], optional = true }
-log = { version = "0.4", optional = true }
-thiserror = { version = "1", optional = true }
-serde_with = { version = "1", optional = true }
-serde_yaml = { version = "0.8", optional = true }
-semver = { version = "1", features = [ "serde" ] }
-url = { version = "2", features = ["serde"], optional = true }
+camino = {version = "1", features = ["serde1"], optional = true}
+log = {version = "0.4", optional = true}
+semver = {version = "1", features = ["serde"]}
+serde_with = {version = "1", optional = true}
+serde_yaml = {version = "0.8", optional = true}
+thiserror = {version = "1", optional = true}
+url = {version = "2", features = ["serde"], optional = true}
 
 # build-only dependencies
-serde_json = { version = "1", optional = true }
+serde_json = {version = "1", optional = true}
 
 [dev-dependencies]
 assert_fs = "1"

--- a/apollo-federation-types/src/build_plugin/build_message.rs
+++ b/apollo-federation-types/src/build_plugin/build_message.rs
@@ -1,0 +1,137 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum BuildMessageLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BuildMessageLocation {
+    line: u32,
+    column: u32,
+
+    #[serde(flatten)]
+    other: crate::UncaughtJson,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildMessage {
+    pub level: BuildMessageLevel,
+    pub message: String,
+    pub step: Option<String>,
+    pub code: Option<String>,
+    pub locations: Vec<BuildMessageLocation>,
+    pub schema_coordinate: Option<String>,
+
+    #[serde(flatten)]
+    other: crate::UncaughtJson,
+}
+
+impl BuildMessage {
+    pub fn to_build_errors(
+        error_messages: Vec<String>,
+        step: Option<String>,
+        code: Option<String>,
+    ) -> Vec<BuildMessage> {
+        error_messages
+            .iter()
+            .map(|error_message| BuildMessage {
+                level: BuildMessageLevel::Error,
+                message: error_message.clone(),
+                step: step.clone(),
+                code: code.clone(),
+                locations: vec![],
+                schema_coordinate: None,
+                other: crate::UncaughtJson::new(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use crate::build_plugin::{
+        build_message::BuildMessageLocation, BuildMessage, BuildMessageLevel,
+    };
+
+    #[test]
+    fn it_can_serialize_build_message() {
+        let build_message: BuildMessage = BuildMessage {
+            level: BuildMessageLevel::Debug,
+            message: "wow".to_string(),
+            step: None,
+            code: None,
+            locations: vec![],
+            schema_coordinate: None,
+            other: crate::UncaughtJson::new(),
+        };
+
+        let actual_value: Value = serde_json::from_str(
+            &serde_json::to_string(&build_message)
+                .expect("Could not convert build errors to string"),
+        )
+        .expect("Could not convert build error string to serde_json::Value");
+
+        let expected_value = json!({
+            "level": "DEBUG",
+            "message": "wow",
+            "step": null,
+            "code": null,
+            "locations": [],
+            "schemaCoordinate": null,
+        });
+        assert_eq!(actual_value, expected_value);
+    }
+
+    #[test]
+    fn it_can_deserialize_even_with_unknown_fields() {
+        let unexpected_key = "this-would-never-happen".to_string();
+        let unexpected_value = "but-maybe-something-else-more-reasonable-would".to_string();
+        let actual_struct = serde_json::from_str(
+            &json!({
+                "level": "DEBUG",
+                "message": "wow",
+                "step": null,
+                "code": null,
+                "locations": [{"line": 1, "column": 2, &unexpected_key: &unexpected_value}],
+                "schemaCoordinate": null,
+                &unexpected_key: &unexpected_value,
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut expected_struct: BuildMessage = BuildMessage {
+            level: BuildMessageLevel::Debug,
+            message: "wow".to_string(),
+            step: None,
+            code: None,
+            locations: vec![BuildMessageLocation {
+                line: 1,
+                column: 2,
+                other: crate::UncaughtJson::new(),
+            }],
+            schema_coordinate: None,
+            other: crate::UncaughtJson::new(),
+        };
+
+        expected_struct.locations[0].other.insert(
+            unexpected_key.clone(),
+            Value::String(unexpected_value.clone()),
+        );
+
+        expected_struct
+            .other
+            .insert(unexpected_key, Value::String(unexpected_value));
+
+        assert_eq!(expected_struct, actual_struct)
+    }
+}

--- a/apollo-federation-types/src/build_plugin/build_message.rs
+++ b/apollo-federation-types/src/build_plugin/build_message.rs
@@ -11,6 +11,9 @@ pub enum BuildMessageLevel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// BuildLocation represents the location of a build message in the GraphQLDoucment
+/// New fields added to this struct must be optional in order to maintain
+/// backwards compatibility with old versions of Rover
 pub struct BuildMessageLocation {
     line: u32,
     column: u32,
@@ -21,6 +24,9 @@ pub struct BuildMessageLocation {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+/// BuildMessages contains the log output of a build
+/// New fields added to this struct must be optional in order to maintain
+/// backwards compatibility with old versions of Rover
 pub struct BuildMessage {
     pub level: BuildMessageLevel,
     pub message: String,

--- a/apollo-federation-types/src/build_plugin/mod.rs
+++ b/apollo-federation-types/src/build_plugin/mod.rs
@@ -1,0 +1,6 @@
+mod build_message;
+mod plugin_result;
+
+pub use build_message::BuildMessage;
+pub use build_message::BuildMessageLevel;
+pub use plugin_result::PluginResult;

--- a/apollo-federation-types/src/build_plugin/plugin_result.rs
+++ b/apollo-federation-types/src/build_plugin/plugin_result.rs
@@ -1,0 +1,157 @@
+use super::BuildMessage;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginResult {
+    pub is_success: bool,
+    pub schema: Option<String>,
+    pub build_messages: Vec<BuildMessage>,
+
+    /// Other untyped JSON included in the build output.
+    #[serde(flatten)]
+    other: crate::UncaughtJson,
+}
+
+impl PluginResult {
+    /**
+    We may succed in Rust's perspective, but inside the JSON message may be isSuccess: false
+    and buildMessages from composition telling us what went wrong.
+
+    If there are, promote those to more semantic places in the output object.
+    If there are not, cooool, pass the data along.
+    */
+    pub fn from_plugin_result(result_json: &str) -> Self {
+        let serde_json: Result<PluginResult, serde_json::Error> = serde_json::from_str(result_json);
+        match serde_json {
+            Ok(js_response) => js_response,
+            Err(json_error) => Self {
+                is_success: false,
+                schema: None,
+                build_messages: BuildMessage::to_build_errors(
+                    vec![format!(
+                        "Could not parse JSON from Rust. Received error {}",
+                        json_error
+                    )],
+                    Some("PLUGIN_EXECUTION".to_string()),
+                    Some("PLUGIN_EXECUTION".to_string()),
+                ),
+                other: crate::UncaughtJson::new(),
+            },
+        }
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!(self)
+    }
+}
+
+#[cfg(feature = "config")]
+impl From<crate::config::ConfigError> for PluginResult {
+    fn from(config_error: crate::config::ConfigError) -> Self {
+        PluginResult {
+            schema: None,
+            build_messages: BuildMessage::to_build_errors(
+                vec![config_error.message()],
+                Some("PLUGIN_CONFIGURATION".to_string()),
+                config_error.code(),
+            ),
+            is_success: false,
+            other: crate::UncaughtJson::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    #[test]
+    fn it_can_serialize_with_success() {
+        let sdl = "my-sdl".to_string();
+        let expected_json = json!({"schema": &sdl, "buildMessages": [], "isSuccess": true});
+        let actual_json = serde_json::to_value(&PluginResult {
+            schema: Some(sdl),
+            build_messages: vec![],
+            is_success: true,
+            other: crate::UncaughtJson::new(),
+        })
+        .unwrap();
+        assert_eq!(expected_json, actual_json)
+    }
+
+    #[test]
+    fn it_can_serialize_with_failure() {
+        let expected_json = json!({
+        "schema": null,
+        "buildMessages": [],
+        "isSuccess": false
+        });
+        let actual_json = serde_json::to_value(&PluginResult {
+            schema: None,
+            build_messages: vec![],
+            is_success: false,
+            other: crate::UncaughtJson::new(),
+        })
+        .expect("Could not serialize PluginResult");
+        assert_eq!(expected_json, actual_json)
+    }
+
+    #[test]
+    fn it_can_deserialize_with_success() {
+        let sdl = "my-sdl".to_string();
+        let actual_struct = serde_json::from_str(
+            &json!({"schema": &sdl, "buildMessages": [], "isSuccess": true}).to_string(),
+        )
+        .unwrap();
+        let expected_struct = PluginResult {
+            schema: Some(sdl),
+            build_messages: vec![],
+            is_success: true,
+            other: crate::UncaughtJson::new(),
+        };
+
+        assert_eq!(expected_struct, actual_struct)
+    }
+
+    #[test]
+    fn it_can_deserialize_with_failure() {
+        let actual_struct = serde_json::from_str(
+            &json!({"schema": null, "buildMessages": [], "isSuccess": false}).to_string(),
+        )
+        .unwrap();
+        let expected_struct = PluginResult {
+            schema: None,
+            build_messages: vec![],
+            is_success: false,
+            other: crate::UncaughtJson::new(),
+        };
+
+        assert_eq!(expected_struct, actual_struct)
+    }
+
+    #[test]
+    fn it_can_deserialize_even_with_unknown_fields() {
+        let sdl = "my-sdl".to_string();
+        let unexpected_key = "this-would-never-happen".to_string();
+        let unexpected_value = "but-maybe-something-else-more-reasonable-would".to_string();
+        let actual_struct = serde_json::from_str(
+            &json!({"schema": &sdl, "buildMessages": [], "isSuccess": true, &unexpected_key: &unexpected_value}).to_string(),
+        )
+        .unwrap();
+        let mut expected_struct = PluginResult {
+            schema: Some(sdl),
+            build_messages: vec![],
+            is_success: true,
+            other: crate::UncaughtJson::new(),
+        };
+
+        expected_struct
+            .other
+            .insert(unexpected_key, Value::String(unexpected_value));
+
+        assert_eq!(expected_struct, actual_struct)
+    }
+}

--- a/apollo-federation-types/src/build_plugin/plugin_result.rs
+++ b/apollo-federation-types/src/build_plugin/plugin_result.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+/// PluginResult represents the output of a plugin execution
+/// New fields added to this struct must be optional in order to maintain
+/// backwards compatibility with old versions of Rover
 pub struct PluginResult {
     pub is_success: bool,
     pub schema: Option<String>,

--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -32,6 +32,18 @@ impl SupergraphConfig {
         Ok(parsed_config)
     }
 
+    /// Create a new SupergraphConfig from a JSON string in memory.
+    pub fn new_from_json(json: &str) -> ConfigResult<SupergraphConfig> {
+        let parsed_config: SupergraphConfig =
+            serde_json::from_str(json).map_err(|e| ConfigError::InvalidConfiguration {
+                message: e.to_string(),
+            })?;
+
+        log::debug!("{:?}", parsed_config);
+
+        Ok(parsed_config)
+    }
+
     /// Create a new SupergraphConfig from a YAML file.
     pub fn new_from_yaml_file<P: Into<Utf8PathBuf>>(
         config_path: P,

--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -168,6 +168,34 @@ subgraphs:
     }
 
     #[test]
+    fn it_can_parse_valid_config_without_version_json() {
+        let raw_good_json = r#"
+{
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
+"#;
+
+        let config = SupergraphConfig::new_from_json(raw_good_json);
+        println!("{:?}", config);
+        assert!(config.is_ok());
+        let config = config.unwrap();
+        assert_eq!(config.federation_version, None);
+    }
+
+    #[test]
     fn it_can_parse_valid_config_fed_zero() {
         let raw_good_yaml = r#"---
 federation_version: 0
@@ -183,6 +211,35 @@ subgraphs:
 "#;
 
         let config = SupergraphConfig::new_from_yaml(raw_good_yaml).unwrap();
+        assert_eq!(
+            config.federation_version,
+            Some(FederationVersion::LatestFedOne)
+        );
+    }
+
+    #[test]
+    fn it_can_parse_valid_config_fed_zero_json() {
+        let raw_json_yaml = r#"
+{
+    "federation_version": 0,
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
+"#;
+
+        let config = SupergraphConfig::new_from_json(raw_json_yaml).unwrap();
         assert_eq!(
             config.federation_version,
             Some(FederationVersion::LatestFedOne)
@@ -212,6 +269,35 @@ subgraphs:
     }
 
     #[test]
+    fn it_can_parse_valid_config_fed_one_json() {
+        let raw_good_json = r#"
+{
+    "federation_version": 1,
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
+"#;
+
+        let config = SupergraphConfig::new_from_json(raw_good_json).unwrap();
+        assert_eq!(
+            config.federation_version,
+            Some(FederationVersion::LatestFedOne)
+        );
+    }
+
+    #[test]
     fn it_can_parse_valid_config_fed_two() {
         let raw_good_yaml = r#"---
 federation_version: 2
@@ -227,6 +313,35 @@ subgraphs:
 "#;
 
         let config = SupergraphConfig::new_from_yaml(raw_good_yaml).unwrap();
+        assert_eq!(
+            config.federation_version,
+            Some(FederationVersion::LatestFedTwo)
+        );
+    }
+
+    #[test]
+    fn it_can_parse_valid_config_fed_two_json() {
+        let raw_good_json = r#"
+{
+    "federation_version": 2,
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
+"#;
+
+        let config = SupergraphConfig::new_from_json(raw_good_json).unwrap();
         assert_eq!(
             config.federation_version,
             Some(FederationVersion::LatestFedTwo)
@@ -258,6 +373,37 @@ subgraphs:
     }
 
     #[test]
+    fn it_can_parse_valid_config_fed_one_exact_json() {
+        let raw_good_json = r#"
+{
+    "federation_version": "=0.36.0",
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
+"#;
+
+        let config = SupergraphConfig::new_from_json(raw_good_json).unwrap();
+        assert_eq!(
+            config.federation_version,
+            Some(FederationVersion::ExactFedOne(
+                Version::parse("0.36.0").unwrap()
+            ))
+        );
+    }
+
+    #[test]
     fn it_can_parse_valid_config_fed_two_exact() {
         let raw_good_yaml = r#"---
 federation_version: =2.0.0
@@ -273,6 +419,37 @@ subgraphs:
 "#;
 
         let config = SupergraphConfig::new_from_yaml(raw_good_yaml).unwrap();
+        assert_eq!(
+            config.federation_version,
+            Some(FederationVersion::ExactFedTwo(
+                Version::parse("2.0.0").unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn it_can_parse_valid_config_fed_two_exact_json() {
+        let raw_good_json = r#"
+{
+    "federation_version": "=2.0.0",
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
+"#;
+
+        let config = SupergraphConfig::new_from_json(raw_good_json).unwrap();
         assert_eq!(
             config.federation_version,
             Some(FederationVersion::ExactFedTwo(
@@ -324,8 +501,52 @@ subgraphs:
     }
 
     #[test]
+    fn it_can_parse_valid_config_with_introspection_json() {
+        let raw_good_json = r#"
+{
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./films.graphql"
+        }
+      },
+      "people": {
+        "schema": {
+          "subgraph_url": "https://people.example.com"
+        }
+      },
+      "reviews": {
+        "schema": {
+          "graphref": "mygraph@current",
+          "subgraph": "reviews"
+        }
+      }
+    }
+  }
+"#;
+
+        assert!(SupergraphConfig::new_from_json(raw_good_json).is_ok());
+    }
+
+    #[test]
     fn it_errors_on_invalid_config() {
         let raw_bad_yaml = r#"---
+subgraphs:
+  films:
+    routing_______url: https://films.example.com
+    schemaaaa:
+        file:: ./good-films.graphql
+  people:
+    routing____url: https://people.example.com
+    schema_____file: ./good-people.graphql"#;
+
+        assert!(SupergraphConfig::new_from_yaml(raw_bad_yaml).is_err())
+    }
+
+    #[test]
+    fn it_errors_on_invalid_config_json() {
+        let raw_bad_yaml = r#"
 subgraphs:
   films:
     routing_______url: https://films.example.com
@@ -351,6 +572,31 @@ subgraphs:
     routing_url: https://people.example.com
     schema:
       file: ./good-people.graphql
+"#;
+
+        assert!(SupergraphConfig::new_from_yaml(raw_good_yaml).is_err())
+    }
+
+    #[test]
+    fn it_errs_on_bad_version_json() {
+        let raw_good_yaml = r#"
+{
+    "federation_version": "3",
+    "subgraphs": {
+      "films": {
+        "routing_url": "https://films.example.com",
+        "schema": {
+          "file": "./good-films.graphql"
+        }
+      },
+      "people": {
+        "routing_url": "https://people.example.com",
+        "schema": {
+          "file": "./good-people.graphql"
+        }
+      }
+    }
+  }
 "#;
 
         assert!(SupergraphConfig::new_from_yaml(raw_good_yaml).is_err())

--- a/apollo-federation-types/src/lib.rs
+++ b/apollo-federation-types/src/lib.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "build")]
 pub mod build;
 
+#[cfg(feature = "build_plugin")]
+pub mod build_plugin;
+
 #[cfg(feature = "config")]
 pub mod config;
 


### PR DESCRIPTION
This PR is easiest to go commit by commit. It adds json parsing for `SupergraphConfig` since we use that in the plugins. It then adds the json types we use as return values for the plugins. 