### PR TITLE
chore: updates macos notarize step from altool to notarytool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,6 +355,7 @@ commands:
         enum: [lint, test, publish, package, dist]
       options:
         type: string
+        default: ""
       platform:
         type: executor
       working_directory:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ workflows:
               platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
-              options: ["--verbose"]
           requires:
             - "Run cargo tests (stable rust on amd_centos)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
@@ -114,7 +113,6 @@ jobs:
         enum: [lint, test, publish, package, dist]
       options:
         type: string
-        default: "--verbose"
     executor: << parameters.platform >>
     steps:
       - checkout
@@ -146,7 +144,7 @@ jobs:
       - exec_xtask:
           platform: << parameters.platform >>
           command: dist
-          options: --verbose --debug
+          options: --debug
      # this should be run before the GitHub release is created
      # because it ensures that all of the files it needs
      # are in place before proceeding.
@@ -356,7 +354,6 @@ commands:
         enum: [lint, test, publish, package, dist]
       options:
         type: string
-        default: --verbose
       platform:
         type: executor
       working_directory:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
         enum: [lint, test, publish, package, dist]
       options:
         type: string
+        default: ""
     executor: << parameters.platform >>
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /artifacts
 **/.DS_Store
 .idea/
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +344,15 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -374,7 +417,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -440,6 +483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +499,16 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
 ]
 
 [[package]]
@@ -531,6 +593,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +674,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -670,6 +760,18 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "shell-candy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf87684817105933918b2eb4bf6c47acddbc3f7f69f6692cef75a314607bc8b"
+dependencies = [
+ "crossbeam-channel",
+ "rayon",
+ "thiserror",
+ "which",
 ]
 
 [[package]]
@@ -1014,6 +1116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_traversal",
+ "shell-candy",
  "structopt",
  "tar",
  "tempfile",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,6 +17,7 @@ semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_json_traversal = "0.2"
+shell-candy = "0.4"
 structopt = { version = "0.3", default-features = false }
 tar = "0.4"
 tempfile = "3.4"

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -23,8 +23,8 @@ pub(crate) struct Dist {
 
 impl Dist {
     /// Builds binary crates
-    pub(crate) fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+    pub(crate) fn run(&self) -> Result<()> {
+        let cargo_runner = CargoRunner::new()?;
         if let Some(package) = &self.package {
             let workspace_dir = package.get_workspace_dir()?;
             cargo_runner.build(&self.target, !self.debug, &workspace_dir)?;

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -12,14 +12,14 @@ pub(crate) struct Lint {
 }
 
 impl Lint {
-    pub(crate) fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+    pub(crate) fn run(&self) -> Result<()> {
+        let cargo_runner = CargoRunner::new()?;
         if let Some(package) = &self.package {
             cargo_runner.lint(&package.get_workspace_dir()?)?;
         } else {
             cargo_runner.lint_all()?;
         }
-        let npm_runner = NpmRunner::new(verbose)?;
+        let npm_runner = NpmRunner::new()?;
         npm_runner.lint()?;
         Ok(())
     }

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -1,11 +1,11 @@
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{ensure, Context, Result};
 use semver::Version;
-use serde_json_traversal::serde_json_traversal;
 use std::io::Write as _;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use structopt::StructOpt;
 
+use crate::tools::XcrunRunner;
 use crate::utils::PKG_PROJECT_ROOT;
 
 const ENTITLEMENTS: &str = "macos-entitlements.plist";
@@ -23,10 +23,6 @@ pub struct PackageMacos {
     /// Certificate bundle keychain_password.
     #[structopt(long, env = "MACOS_CERT_BUNDLE_PASSWORD", hide_env_values = true)]
     cert_bundle_password: String,
-
-    /// Primary bundle ID.
-    #[structopt(long, env = "MACOS_PRIMARY_BUNDLE_ID")]
-    primary_bundle_id: String,
 
     /// Apple team ID.
     #[structopt(long, env = "APPLE_TEAM_ID")]
@@ -207,82 +203,19 @@ impl PackageMacos {
         )?;
         zip.finish()?;
 
-        crate::info!("Beginning notarization process...");
-        let output = Command::new("xcrun")
-            .args(["altool", "--notarize-app", "--primary-bundle-id"])
-            .arg(&self.primary_bundle_id)
-            .arg("--username")
-            .arg(&self.apple_username)
-            .arg("--password")
-            .arg(&self.notarization_password)
-            .arg("--asc-provider")
-            .arg(&self.apple_team_id)
-            .arg("--file")
-            .arg(&dist_zip)
-            .args(["--output-format", "json"])
-            .stderr(Stdio::inherit())
-            .output()
-            .context("could not start command xcrun")?;
-        let _ = std::io::stdout().write(&output.stdout);
-        ensure!(output.status.success(), "command exited with error",);
-        let json: serde_json::Value =
-            serde_json::from_slice(&output.stdout).context("could not parse json output")?;
-        let success_message = serde_json_traversal!(json => success-message)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let request_uuid = serde_json_traversal!(json => notarization-upload => RequestUUID)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        crate::info!("Success message: {}", success_message);
-        crate::info!("Request UUID: {}", request_uuid);
+        let dist_zip = dist_zip.to_str().unwrap_or_else(|| {
+            panic!(
+                "path to zipped directory '{}' is not valid utf-8",
+                dist_zip.display()
+            )
+        });
 
-        let start_time = std::time::Instant::now();
-        let duration = std::time::Duration::from_secs(60 * 10);
-        let result = loop {
-            crate::info!("Checking notarization status...");
-            let output = Command::new("xcrun")
-                .args(["altool", "--notarization-info"])
-                .arg(request_uuid)
-                .arg("--username")
-                .arg(&self.apple_username)
-                .arg("--password")
-                .arg(&self.notarization_password)
-                .args(["--output-format", "json"])
-                .stderr(Stdio::inherit())
-                .output()
-                .context("could not start command xcrun")?;
-
-            let status = if !output.status.success() {
-                // NOTE: if the exit status is failure we need to keep trying otherwise the
-                //       process becomes a bit flaky
-                crate::info!("command exited with error");
-                None
-            } else {
-                let json: serde_json::Value = serde_json::from_slice(&output.stdout)
-                    .context("could not parse json output")?;
-                serde_json_traversal!(json => notarization-info => Status)
-                    .ok()
-                    .and_then(|x| x.as_str())
-                    .map(|x| x.to_string())
-            };
-
-            if !matches!(
-                status.as_deref(),
-                Some("in progress") | None if start_time.elapsed() < duration
-            ) {
-                break status;
-            }
-
-            std::thread::sleep(std::time::Duration::from_secs(5));
-        };
-        match result.as_deref() {
-            Some("success") => crate::info!("Notarization successful"),
-            Some("in progress") => bail!("Notarization timeout"),
-            Some(other) => bail!("Notarization failed: {}", other),
-            None => bail!("Notarization failed without status message"),
-        }
+        XcrunRunner::new().notarize(
+            dist_zip,
+            &self.apple_username,
+            &self.apple_team_id,
+            &self.notarization_password,
+        )?;
 
         Ok(())
     }

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -36,13 +36,13 @@ pub struct Package {
 }
 
 impl Package {
-    pub fn run(&self, verbose: bool) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
         Dist {
             target: self.target.clone(),
             package: Some(self.package.clone()),
             debug: self.debug,
         }
-        .run(verbose)
+        .run()
         .context("Could not build package")?;
         self.package_tarball()?;
         Ok(())

--- a/xtask/src/commands/publish.rs
+++ b/xtask/src/commands/publish.rs
@@ -11,8 +11,8 @@ pub(crate) struct Publish {
 }
 
 impl Publish {
-    pub fn run(&self, verbose: bool) -> Result<()> {
-        let git_runner = GitRunner::new(true)?;
+    pub fn run(&self) -> Result<()> {
+        let git_runner = GitRunner::new()?;
 
         // Check if (git) HEAD is pointing to a package tag
         //
@@ -42,7 +42,7 @@ impl Publish {
         // PackageGroup::get_library(&self) -> Option<LibraryCrate>
         // and handle it here.
 
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let cargo_runner = CargoRunner::new()?;
         cargo_runner.publish(
             &package_tag.package_group.get_library(),
             &workspace_directory,

--- a/xtask/src/commands/tag.rs
+++ b/xtask/src/commands/tag.rs
@@ -19,10 +19,10 @@ pub(crate) struct Tag {
 }
 
 impl Tag {
-    pub(crate) fn run(&self, verbose: bool) -> Result<()> {
-        let git_runner = GitRunner::new(verbose)?;
+    pub(crate) fn run(&self) -> Result<()> {
+        let git_runner = GitRunner::new()?;
         git_runner.can_tag()?;
-        let cargo_runner = CargoRunner::new(verbose)?;
+        let cargo_runner = CargoRunner::new()?;
         cargo_runner.build_all(&Target::Other, false)?;
         git_runner.tag_release(&self.package, !self.real_publish)?;
         Ok(())

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -13,8 +13,8 @@ pub(crate) struct Test {
 
 impl Test {
     /// Tests crates
-    pub(crate) fn run(&self, verbose: bool) -> Result<()> {
-        let cargo_runner = CargoRunner::new(verbose)?;
+    pub(crate) fn run(&self) -> Result<()> {
+        let cargo_runner = CargoRunner::new()?;
         if let Some(package) = &self.package {
             let workspace_dir = package.get_workspace_dir()?;
             cargo_runner.test(&workspace_dir)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,10 +22,6 @@ fn main() -> Result<()> {
 struct Xtask {
     #[structopt(subcommand)]
     pub command: Command,
-
-    /// Specify xtask's verbosity level
-    #[structopt(long = "verbose", short = "v", global = true)]
-    verbose: bool,
 }
 
 #[derive(Debug, StructOpt)]
@@ -52,12 +48,12 @@ pub(crate) enum Command {
 impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
-            Command::Dist(command) => command.run(self.verbose).map(|_| ()),
-            Command::Lint(command) => command.run(self.verbose),
-            Command::Package(command) => command.run(self.verbose),
-            Command::Publish(command) => command.run(self.verbose),
-            Command::Tag(command) => command.run(self.verbose),
-            Command::Test(command) => command.run(self.verbose),
+            Command::Dist(command) => command.run().map(|_| ()),
+            Command::Lint(command) => command.run(),
+            Command::Package(command) => command.run(),
+            Command::Publish(command) => command.run(),
+            Command::Tag(command) => command.run(),
+            Command::Test(command) => command.run(),
         }?;
         eprintln!("{}", Green.bold().paint("Success!"));
         Ok(())

--- a/xtask/src/tools/cargo.rs
+++ b/xtask/src/tools/cargo.rs
@@ -16,8 +16,8 @@ pub(crate) struct CargoRunner {
 }
 
 impl CargoRunner {
-    pub(crate) fn new(verbose: bool) -> Result<Self> {
-        let runner = Runner::new("cargo", verbose)?;
+    pub(crate) fn new() -> Result<Self> {
+        let runner = Runner::new("cargo");
         let workspace_roots =
             utils::get_workspace_roots().context("Could not find one or more required packages")?;
         Ok(Self {

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -11,8 +11,8 @@ pub(crate) struct GitRunner {
 }
 
 impl GitRunner {
-    pub(crate) fn new(verbose: bool) -> Result<Self> {
-        let runner = Runner::new("git", verbose)?;
+    pub(crate) fn new() -> Result<Self> {
+        let runner = Runner::new("git");
         let repo_path = Utf8PathBuf::try_from(env::current_dir()?)?;
 
         Ok(GitRunner { runner, repo_path })

--- a/xtask/src/tools/mod.rs
+++ b/xtask/src/tools/mod.rs
@@ -3,7 +3,13 @@ mod git;
 mod npm;
 mod runner;
 
+#[cfg(target_os = "macos")]
+mod xcrun;
+
 pub(crate) use cargo::CargoRunner;
 pub(crate) use git::GitRunner;
 pub(crate) use npm::NpmRunner;
 pub(crate) use runner::Runner;
+
+#[cfg(target_os = "macos")]
+pub(crate) use xcrun::XcrunRunner;

--- a/xtask/src/tools/npm.rs
+++ b/xtask/src/tools/npm.rs
@@ -15,9 +15,9 @@ pub(crate) struct NpmRunner {
 }
 
 impl NpmRunner {
-    pub(crate) fn new(verbose: bool) -> Result<Self> {
+    pub(crate) fn new() -> Result<Self> {
         Self::require_volta()?;
-        let runner = Runner::new("npm", verbose)?;
+        let runner = Runner::new("npm");
 
         let workspace_roots =
             utils::get_workspace_roots().context("Could not find one or more required packages")?;

--- a/xtask/src/tools/runner.rs
+++ b/xtask/src/tools/runner.rs
@@ -1,98 +1,78 @@
 use crate::utils::CommandOutput;
 
-use anyhow::{anyhow, Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
-use which::which;
+use anyhow::Result;
+use camino::Utf8PathBuf;
+use shell_candy::{ShellTask, ShellTaskBehavior, ShellTaskLog, ShellTaskOutput};
 
 use std::collections::HashMap;
-use std::convert::TryInto;
-use std::process::{Command, Output, Stdio};
 use std::str;
 
 pub(crate) struct Runner {
-    pub(crate) verbose: bool,
-    pub(crate) tool_name: String,
-    pub(crate) tool_exe: Utf8PathBuf,
+    pub(crate) bin: String,
+    pub(crate) override_bash_descriptor: Option<String>,
 }
 
 impl Runner {
-    pub(crate) fn new(tool_name: &str, verbose: bool) -> Result<Self> {
-        let tool_exe = which(tool_name).with_context(|| {
-            format!(
-                "You must have {} installed to run this command.",
-                &tool_name
-            )
-        })?;
-        Ok(Runner {
-            verbose,
-            tool_name: tool_name.to_string(),
-            tool_exe: tool_exe.try_into()?,
-        })
+    pub(crate) fn new(bin: &str) -> Self {
+        Runner {
+            bin: bin.to_string(),
+            override_bash_descriptor: None,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn set_bash_descriptor(&mut self, new_bash_descriptor: String) {
+        self.override_bash_descriptor = Some(new_bash_descriptor);
+    }
+
+    fn get_bash_descriptor(&self, task: &ShellTask) -> String {
+        self.override_bash_descriptor
+            .clone()
+            .unwrap_or_else(|| task.bash_descriptor())
     }
 
     pub(crate) fn exec(
         &self,
         args: &[&str],
-        directory: &Utf8Path,
+        directory: &Utf8PathBuf,
         env: Option<&HashMap<String, String>>,
     ) -> Result<CommandOutput> {
-        let full_command = format!("`{} {}`", &self.tool_name, args.join(" "));
-        crate::info!("running {} in `{}`", &full_command, directory);
-        if self.verbose {
-            if let Some(env) = env {
-                crate::info!("env:");
-                for (key, value) in env {
-                    crate::info!("  ${}={}", key, value);
+        let mut task = ShellTask::new(&format!(
+            "{bin} {args}",
+            bin = &self.bin,
+            args = args.join(" ")
+        ))?;
+        task.current_dir(directory);
+        if let Some(env) = env {
+            for (k, v) in env {
+                task.env(k, v);
+            }
+        }
+        let bin = self.bin.to_string();
+        crate::info!("{}", &self.get_bash_descriptor(&task));
+        let task_result = task.run(move |line| {
+            match line {
+                ShellTaskLog::Stdout(line) | ShellTaskLog::Stderr(line) => {
+                    crate::info!("({bin}) | {line}", bin = bin, line = line);
                 }
             }
-        }
-
-        let mut command = Command::new(&self.tool_exe);
-        command
-            .current_dir(directory)
-            .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        if let Some(env) = env {
-            command.envs(env);
-        }
-        let child = command
-            .spawn()
-            .with_context(|| "Could not spawn child process")?;
-        let output = child
-            .wait_with_output()
-            .with_context(|| "Failed to wait for child process to exit")?;
-        self.handle_command_output(output)
-            .with_context(|| format!("Encountered an issue while executing {}", &full_command))
-    }
-
-    fn handle_command_output(&self, output: Output) -> Result<CommandOutput> {
-        let command_was_successful = output.status.success();
-        let stdout = str::from_utf8(&output.stdout)
-            .context("Command's stdout was not valid UTF-8.")?
-            .to_string();
-        let stderr = str::from_utf8(&output.stderr)
-            .context("Command's stderr was not valid UTF-8.")?
-            .to_string();
-        if self.verbose || !command_was_successful {
-            if !stderr.is_empty() {
-                eprintln!("{}", &stderr);
+            ShellTaskBehavior::<()>::Passthrough
+        })?;
+        match task_result {
+            ShellTaskOutput::CompleteOutput {
+                status: _,
+                stdout_lines,
+                stderr_lines,
             }
-            if !stdout.is_empty() {
-                println!("{}", &stdout);
-            }
-        }
-
-        if command_was_successful {
-            Ok(CommandOutput {
-                stdout,
-                _stderr: stderr,
-                _output: output,
-            })
-        } else if let Some(exit_code) = output.status.code() {
-            Err(anyhow!("Exited with status code {}", exit_code))
-        } else {
-            Err(anyhow!("Terminated by a signal."))
+            | ShellTaskOutput::EarlyReturn {
+                stdout_lines,
+                stderr_lines,
+                return_value: _,
+            } => Ok(CommandOutput {
+                stdout: stdout_lines.join("\n"),
+                _stderr: stderr_lines.join("\n"),
+                _directory: directory.clone(),
+            }),
         }
     }
 }

--- a/xtask/src/tools/xcrun.rs
+++ b/xtask/src/tools/xcrun.rs
@@ -1,0 +1,56 @@
+use crate::tools::Runner;
+use crate::utils::PKG_PROJECT_ROOT;
+
+use anyhow::{anyhow, Result};
+
+pub(crate) struct XcrunRunner {
+    runner: Runner,
+}
+
+impl XcrunRunner {
+    pub(crate) fn new() -> Self {
+        let runner = Runner::new("xcrun");
+
+        XcrunRunner { runner }
+    }
+
+    pub(crate) fn notarize(
+        &mut self,
+        dist_zip: &str,
+        apple_username: &str,
+        apple_team_id: &str,
+        notarization_password: &str,
+    ) -> Result<()> {
+        crate::info!("Beginning notarization process...");
+        self.runner.set_bash_descriptor(format!("xcrun notarytool submit {dist_zip} --apple-id {apple_username} --apple-team-id {apple_team_id} --password xxxx-xxxx-xxxx-xxxx --wait --timeout 20m"));
+        let project_root = PKG_PROJECT_ROOT.clone();
+        self.runner
+            .exec(
+                &[
+                    "notarytool",
+                    "submit",
+                    dist_zip,
+                    "--apple-id",
+                    apple_username,
+                    "--team-id",
+                    apple_team_id,
+                    "--password",
+                    notarization_password,
+                    "--wait",
+                    "--timeout",
+                    "20m",
+                ],
+                &project_root,
+                None,
+            )
+            .map_err(|e| {
+                anyhow!(
+                    "{}",
+                    e.to_string()
+                        .replace(notarization_password, "xxxx-xxxx-xxxx-xxxx")
+                )
+            })?;
+        crate::info!("Notarization successful.");
+        Ok(())
+    }
+}

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
 use lazy_static::lazy_static;
 
-use std::{convert::TryFrom, env, process::Output, str};
+use std::{convert::TryFrom, env, str};
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -59,5 +59,5 @@ fn project_root() -> Result<Utf8PathBuf> {
 pub(crate) struct CommandOutput {
     pub(crate) stdout: String,
     pub(crate) _stderr: String,
-    pub(crate) _output: Output,
+    pub(crate) _directory: Utf8PathBuf,
 }


### PR DESCRIPTION
similar PR to what was done in rover https://github.com/apollographql/rover/pull/1658

moves our notarize step from `altool` with manual polling to the new `notarytool` which will wait for the notarization to complete without needing to manually poll. also moved our runner implementation to use `ShellTask` so watching CI builds will be a bit more interesting and less "print everything that happened to stdout after waiting 5 minutes"