### PR TITLE
Modify plugin result data types

### DIFF
--- a/apollo-federation-types/src/build_plugin/build_message.rs
+++ b/apollo-federation-types/src/build_plugin/build_message.rs
@@ -15,11 +15,23 @@ pub enum BuildMessageLevel {
 /// New fields added to this struct must be optional in order to maintain
 /// backwards compatibility with old versions of Rover
 pub struct BuildMessageLocation {
-    line: u32,
-    column: u32,
+    pub subgraph: Option<String>,
+
+    pub source: Option<String>,
+
+    pub start: Option<BuildMessagePoint>,
+    pub end: Option<BuildMessagePoint>,
 
     #[serde(flatten)]
     other: crate::UncaughtJson,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BuildMessagePoint {
+    pub start: Option<u32>,
+    pub end: Option<u32>,
+    pub column: Option<u32>,
+    pub line: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -100,7 +112,7 @@ mod tests {
                 "message": "wow",
                 "step": null,
                 "code": null,
-                "locations": [{"line": 1, "column": 2, &unexpected_key: &unexpected_value}],
+                "locations": [{&unexpected_key: &unexpected_value}],
                 "schemaCoordinate": null,
                 &unexpected_key: &unexpected_value,
             })
@@ -114,8 +126,10 @@ mod tests {
             step: None,
             code: None,
             locations: vec![BuildMessageLocation {
-                line: 1,
-                column: 2,
+                subgraph: None,
+                source: None,
+                start: None,
+                end: None,
                 other: crate::UncaughtJson::new(),
             }],
             schema_coordinate: None,

--- a/apollo-federation-types/src/build_plugin/build_message.rs
+++ b/apollo-federation-types/src/build_plugin/build_message.rs
@@ -40,23 +40,16 @@ pub struct BuildMessage {
 }
 
 impl BuildMessage {
-    pub fn to_build_errors(
-        error_messages: Vec<String>,
-        step: Option<String>,
-        code: Option<String>,
-    ) -> Vec<BuildMessage> {
-        error_messages
-            .iter()
-            .map(|error_message| BuildMessage {
-                level: BuildMessageLevel::Error,
-                message: error_message.clone(),
-                step: step.clone(),
-                code: code.clone(),
-                locations: vec![],
-                schema_coordinate: None,
-                other: crate::UncaughtJson::new(),
-            })
-            .collect()
+    pub fn new_error(error_message: String, step: Option<String>, code: Option<String>) -> Self {
+        BuildMessage {
+            level: BuildMessageLevel::Error,
+            message: error_message,
+            step,
+            code,
+            locations: vec![],
+            schema_coordinate: None,
+            other: crate::UncaughtJson::new(),
+        }
     }
 }
 

--- a/apollo-federation-types/src/build_plugin/mod.rs
+++ b/apollo-federation-types/src/build_plugin/mod.rs
@@ -3,4 +3,6 @@ mod plugin_result;
 
 pub use build_message::BuildMessage;
 pub use build_message::BuildMessageLevel;
+pub use build_message::BuildMessageLocation;
+pub use build_message::BuildMessagePoint;
 pub use plugin_result::PluginResult;

--- a/apollo-federation-types/src/build_plugin/mod.rs
+++ b/apollo-federation-types/src/build_plugin/mod.rs
@@ -5,4 +5,5 @@ pub use build_message::BuildMessage;
 pub use build_message::BuildMessageLevel;
 pub use build_message::BuildMessageLocation;
 pub use build_message::BuildMessagePoint;
+pub use plugin_result::PluginFailureReason;
 pub use plugin_result::PluginResult;

--- a/apollo-federation-types/src/build_plugin/plugin_result.rs
+++ b/apollo-federation-types/src/build_plugin/plugin_result.rs
@@ -1,19 +1,27 @@
 use super::BuildMessage;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+// This represents the reason for a build failrue
+pub enum PluginFailureReason {
+    /// If the plugin failed because user inputs can't be built
+    Build,
+    /// If the configuration sent to the plugin is invalid
+    Config,
+    /// If the plugin failed for some internal reason
+    InternalFailure,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// PluginResult represents the output of a plugin execution
 /// New fields added to this struct must be optional in order to maintain
 /// backwards compatibility with old versions of Rover
 pub struct PluginResult {
-    pub is_success: bool,
-    pub schema: Option<String>,
+    pub result: Result<String, PluginFailureReason>,
     pub build_messages: Vec<BuildMessage>,
-
-    // We need to keep the default for backwards compatibility
-    #[serde(default = "bool::default")]
-    is_non_build_failure: bool,
 
     /// Other untyped JSON included in the build output.
     #[serde(flatten)]
@@ -21,17 +29,23 @@ pub struct PluginResult {
 }
 
 impl PluginResult {
-    /// Returns true if the failure is due to something other than the execution of the underlying javascript code
-    /// e.g. the supergraph yaml is misconfigured or the json recieved is malformed
-    pub fn is_non_build_failure(&self) -> bool {
-        self.is_non_build_failure && self.schema.is_none() && !self.is_success
+    pub fn new(
+        result: Result<String, PluginFailureReason>,
+        build_messages: Vec<BuildMessage>,
+    ) -> Self {
+        Self {
+            result,
+            build_messages,
+            other: crate::UncaughtJson::new(),
+        }
     }
 
-    pub fn internal_failure_result(build_messages: Vec<BuildMessage>) -> Self {
+    pub fn new_failure(
+        build_messages: Vec<BuildMessage>,
+        execution_failure: PluginFailureReason,
+    ) -> Self {
         Self {
-            schema: None,
-            is_non_build_failure: true,
-            is_success: false,
+            result: Err(execution_failure),
             build_messages,
             other: crate::UncaughtJson::new(),
         }
@@ -39,9 +53,7 @@ impl PluginResult {
 
     pub fn success_from_schema(schema: String) -> Self {
         Self {
-            schema: Some(schema),
-            is_non_build_failure: true,
-            is_success: false,
+            result: Ok(schema),
             build_messages: vec![],
             other: crate::UncaughtJson::new(),
         }
@@ -58,16 +70,17 @@ impl PluginResult {
         let serde_json: Result<PluginResult, serde_json::Error> = serde_json::from_str(result_json);
         match serde_json {
             Ok(js_response) => js_response,
-            Err(json_error) => {
-                PluginResult::internal_failure_result(vec![BuildMessage::new_error(
+            Err(json_error) => PluginResult::new_failure(
+                vec![BuildMessage::new_error(
                     format!(
                         "Could not parse JSON from Rust. Received error {}",
                         json_error
                     ),
                     Some("PLUGIN_EXECUTION".to_string()),
                     Some("PLUGIN_EXECUTION".to_string()),
-                )])
-            }
+                )],
+                PluginFailureReason::InternalFailure,
+            ),
         }
     }
 
@@ -79,11 +92,14 @@ impl PluginResult {
 #[cfg(feature = "config")]
 impl From<crate::config::ConfigError> for PluginResult {
     fn from(config_error: crate::config::ConfigError) -> Self {
-        PluginResult::internal_failure_result(vec![BuildMessage::new_error(
-            config_error.message(),
-            Some("PLUGIN_CONFIGURATION".to_string()),
-            config_error.code(),
-        )])
+        PluginResult::new_failure(
+            vec![BuildMessage::new_error(
+                config_error.message(),
+                Some("PLUGIN_CONFIGURATION".to_string()),
+                config_error.code(),
+            )],
+            PluginFailureReason::Config,
+        )
     }
 }
 
@@ -96,12 +112,10 @@ mod tests {
     #[test]
     fn it_can_serialize_with_success() {
         let sdl = "my-sdl".to_string();
-        let expected_json = json!({"schema": &sdl, "buildMessages": [], "isSuccess": true, "isNonBuildFailure": false});
-        let actual_json = serde_json::to_value(&PluginResult {
-            schema: Some(sdl),
+        let expected_json = json!({"result":{ "Ok": &sdl}, "buildMessages": []});
+        let actual_json = serde_json::to_value(PluginResult {
+            result: Ok(sdl),
             build_messages: vec![],
-            is_success: true,
-            is_non_build_failure: false,
             other: crate::UncaughtJson::new(),
         })
         .unwrap();
@@ -111,16 +125,12 @@ mod tests {
     #[test]
     fn it_can_serialize_with_failure() {
         let expected_json = json!({
-        "schema": null,
+        "result": {"Err": "build"},
         "buildMessages": [],
-        "isSuccess": false,
-        "isNonBuildFailure": false,
         });
-        let actual_json = serde_json::to_value(&PluginResult {
-            schema: None,
+        let actual_json = serde_json::to_value(PluginResult {
+            result: Err(PluginFailureReason::Build),
             build_messages: vec![],
-            is_success: false,
-            is_non_build_failure: false,
             other: crate::UncaughtJson::new(),
         })
         .expect("Could not serialize PluginResult");
@@ -130,15 +140,12 @@ mod tests {
     #[test]
     fn it_can_deserialize_with_success() {
         let sdl = "my-sdl".to_string();
-        let actual_struct = serde_json::from_str(
-            &json!({"schema": &sdl, "buildMessages": [], "isSuccess": true}).to_string(),
-        )
-        .unwrap();
+        let actual_struct =
+            serde_json::from_str(&json!({"result": {"Ok": &sdl}, "buildMessages": []}).to_string())
+                .unwrap();
         let expected_struct = PluginResult {
-            schema: Some(sdl),
+            result: Ok(sdl),
             build_messages: vec![],
-            is_success: true,
-            is_non_build_failure: false,
             other: crate::UncaughtJson::new(),
         };
 
@@ -148,14 +155,12 @@ mod tests {
     #[test]
     fn it_can_deserialize_with_failure() {
         let actual_struct = serde_json::from_str(
-            &json!({"schema": null, "buildMessages": [], "isSuccess": false}).to_string(),
+            &json!({"result": {"Err": "build"}, "buildMessages": []}).to_string(),
         )
         .unwrap();
         let expected_struct = PluginResult {
-            schema: None,
+            result: Err(PluginFailureReason::Build),
             build_messages: vec![],
-            is_success: false,
-            is_non_build_failure: false,
             other: crate::UncaughtJson::new(),
         };
 
@@ -168,14 +173,12 @@ mod tests {
         let unexpected_key = "this-would-never-happen".to_string();
         let unexpected_value = "but-maybe-something-else-more-reasonable-would".to_string();
         let actual_struct = serde_json::from_str(
-            &json!({"schema": &sdl, "buildMessages": [], "isSuccess": true, &unexpected_key: &unexpected_value}).to_string(),
+            &json!({"result": {"Ok": &sdl}, "buildMessages": [], &unexpected_key: &unexpected_value}).to_string(),
         )
         .unwrap();
         let mut expected_struct = PluginResult {
-            schema: Some(sdl),
+            result: Ok(sdl),
             build_messages: vec![],
-            is_success: true,
-            is_non_build_failure: false,
             other: crate::UncaughtJson::new(),
         };
 


### PR DESCRIPTION
### Add non build failure boolean to plugin result
We want to be able to easily differentiate build failures that are related to bugs in calling a plugin from those that are related to non-composing schemas.

We could theoretically use code for this, but we don't have standardization on codes yet. I think adding a new boolean instead will be the best for now, and we can revisit using codes on build messages to indicate this in the future instead.

### Update Message location to match current composition and rover
The original format was based on what the plugins currently output, however we want to support the same set of location based functionality as in rover and composition. This PR updates the locations to match the current rover/composition format, and a subsequent PR will update the plugins to output this format as well.

### Change `BuildMessage::to_build_errors` to a more traditional style constructor in `BuildMessage::new_error`
We never ended up passing a vec of messages instead, we always passed a single one which made this function a bit tedious. The new format is a bit nicer to create adhoc errors with.