### PR TITLE
release: router-bridge@v0.3.0+v2.4.8

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.2.9+v2.4.8"
+version = "0.3.0+v2.4.8"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router-bridge"
-version = "0.2.9+v2.4.8"
+version = "0.3.0+v2.4.8"
 authors = ["Apollo <packages@apollographql.com>"]
 edition = "2018"
 description = "JavaScript bridge for the Apollo Router"


### PR DESCRIPTION
republish 0.2.9 as 0.3.0 because it included a breaking change.
