### PR TITLE
chore: xtask tag now also creates an empty commit

### DIFF
--- a/xtask/src/commands/tag.rs
+++ b/xtask/src/commands/tag.rs
@@ -25,6 +25,7 @@ impl Tag {
         let cargo_runner = CargoRunner::new()?;
         cargo_runner.build_all(&Target::Other, false)?;
         git_runner.tag_release(&self.package, !self.real_publish)?;
+        git_runner.empty_commit(&self.package, !self.real_publish)?;
         Ok(())
     }
 }

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -132,6 +132,22 @@ impl GitRunner {
         Ok(())
     }
 
+    // takes a PackageTag and creates an empty commit after publish
+    pub(crate) fn empty_commit(&self, package_tag: &PackageTag, dry_run: bool) -> Result<()> {
+        if !dry_run {
+            self.exec(&[
+                "commit",
+                "--allow-empty",
+                "-m",
+                &format!("fixup: empty commit after releasing {package_tag} to make bots happy"),
+            ])?;
+            self.exec(&["push"])?;
+        } else {
+            crate::info!("would run `git commit --allow-empty -m \"fixup: empty commit after releasing {} to make bots happy\" && git push`", &package_tag);
+        }
+        Ok(())
+    }
+
     fn exec(&self, arguments: &[&str]) -> Result<CommandOutput> {
         self.runner.exec(arguments, &self.repo_path, None)
     }


### PR DESCRIPTION
in order to prevent errors where releases fail due to `apollo-federation-types` being published and the tag coexisting at `HEAD` along with other packages, each `cargo xtask tag` invocation will also push an empty commit to `main`.