### PR TITLE
router-bridge: expose reuse_query_fragments QueryPlanner option

### DIFF
--- a/federation-2/router-bridge/src/introspect.rs
+++ b/federation-2/router-bridge/src/introspect.rs
@@ -308,6 +308,7 @@ fragment TypeRef on __Type {
                     enable_defer: Some(true),
                 }),
                 graphql_validation: true,
+                reuse_query_fragments: None,
             },
         )
         .unwrap();

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -642,6 +642,18 @@ pub struct QueryPlannerConfig {
     pub incremental_delivery: Option<IncrementalDeliverySupport>,
     /// Whether to validate GraphQL schema and query text
     pub graphql_validation: bool,
+    /// Whether the query planner should try to reused the named fragments of the planned query in subgraph fetches.
+    ///
+    /// This is often a good idea as it can prevent very large subgraph queries in some cases (named fragments can
+    /// make some relatively small queries (using said fragments) expand to a very large query if all the spreads
+    /// are inline). However, due to architecture of the query planner, this optimization is done as an additional
+    /// pass on the subgraph queries of the generated plan and can thus increase the latency of building a plan.
+    /// As long as query plans are sufficiently cached, this should not be a problem, which is why this option is
+    /// enabled by default, but if the distribution of inbound queries prevents efficient caching of query plans,
+    /// this may become an undesirable trade-off and cand be disabled in that case.
+    ///
+    /// Defaults to true.
+    pub reuse_query_fragments: Option<bool>,
 }
 
 impl Default for QueryPlannerConfig {
@@ -651,6 +663,7 @@ impl Default for QueryPlannerConfig {
                 enable_defer: Some(false),
             }),
             graphql_validation: true,
+            reuse_query_fragments: None,
         }
     }
 }
@@ -679,6 +692,8 @@ mod tests {
     const QUERY2: &str = include_str!("testdata/query2.graphql");
     const MULTIPLE_QUERIES: &str = include_str!("testdata/query_with_multiple_operations.graphql");
     const NO_OPERATION: &str = include_str!("testdata/no_operation.graphql");
+    const QUERY_REUSE_QUERY_FRAGMENTS: &str =
+        include_str!("testdata/query_reuse_query_fragments.graphql");
 
     const MULTIPLE_ANONYMOUS_QUERIES: &str =
         include_str!("testdata/query_with_multiple_anonymous_operations.graphql");
@@ -686,6 +701,8 @@ mod tests {
     const SCHEMA: &str = include_str!("testdata/schema.graphql");
     const SCHEMA_WITHOUT_REVIEW_BODY: &str =
         include_str!("testdata/schema_without_review_body.graphql");
+    const SCHEMA_REUSE_QUERY_FRAGMENTS: &str =
+        include_str!("testdata/schema_reuse_query_fragments.graphql");
     const CORE_IN_V0_1: &str = include_str!("testdata/core_in_v0.1.graphql");
     const UNSUPPORTED_FEATURE: &str = include_str!("testdata/unsupported_feature.graphql");
     const UNSUPPORTED_FEATURE_FOR_EXECUTION: &str =
@@ -770,9 +787,66 @@ mod tests {
             .into_result()
             .unwrap();
         insta::assert_snapshot!(serde_json::to_string_pretty(&payload.data).unwrap());
-        insta::with_settings!({sort_maps => true}, {
-            insta::assert_json_snapshot!(payload.usage_reporting);
-        });
+    }
+
+    #[tokio::test]
+    async fn reuse_query_fragments_defaults_to_true() {
+        let planner = Planner::<serde_json::Value>::new(
+            SCHEMA_REUSE_QUERY_FRAGMENTS.to_string(),
+            QueryPlannerConfig::default(),
+        )
+        .await
+        .unwrap();
+
+        let payload = planner
+            .plan(QUERY_REUSE_QUERY_FRAGMENTS.to_string(), None)
+            .await
+            .unwrap()
+            .into_result()
+            .unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&payload.data).unwrap());
+    }
+
+    #[tokio::test]
+    async fn reuse_query_fragments_explicit_true() {
+        let planner = Planner::<serde_json::Value>::new(
+            SCHEMA_REUSE_QUERY_FRAGMENTS.to_string(),
+            QueryPlannerConfig {
+                reuse_query_fragments: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let payload = planner
+            .plan(QUERY_REUSE_QUERY_FRAGMENTS.to_string(), None)
+            .await
+            .unwrap()
+            .into_result()
+            .unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&payload.data).unwrap());
+    }
+
+    #[tokio::test]
+    async fn reuse_query_fragments_false() {
+        let planner = Planner::<serde_json::Value>::new(
+            SCHEMA_REUSE_QUERY_FRAGMENTS.to_string(),
+            QueryPlannerConfig {
+                reuse_query_fragments: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let payload = planner
+            .plan(QUERY_REUSE_QUERY_FRAGMENTS.to_string(), None)
+            .await
+            .unwrap()
+            .into_result()
+            .unwrap();
+        insta::assert_snapshot!(serde_json::to_string_pretty(&payload.data).unwrap());
     }
 
     #[tokio::test]
@@ -1805,6 +1879,7 @@ feature https://specs.apollo.dev/unsupported-feature/v0.1 is for: SECURITY but i
                     enable_defer: Some(true),
                 }),
                 graphql_validation: true,
+                reuse_query_fragments: None,
             },
         )
         .await
@@ -1881,6 +1956,7 @@ feature https://specs.apollo.dev/unsupported-feature/v0.1 is for: SECURITY but i
                     enable_defer: Some(true),
                 }),
                 graphql_validation: true,
+                reuse_query_fragments: None,
             },
         )
         .await

--- a/federation-2/router-bridge/src/planner.rs
+++ b/federation-2/router-bridge/src/planner.rs
@@ -650,9 +650,10 @@ pub struct QueryPlannerConfig {
     /// pass on the subgraph queries of the generated plan and can thus increase the latency of building a plan.
     /// As long as query plans are sufficiently cached, this should not be a problem, which is why this option is
     /// enabled by default, but if the distribution of inbound queries prevents efficient caching of query plans,
-    /// this may become an undesirable trade-off and cand be disabled in that case.
+    /// this may become an undesirable trade-off and can be disabled in that case.
     ///
-    /// Defaults to true.
+    /// Defaults to `true` in the JS query planner. Defaults to `None` here in order to defer to the JS query
+    /// planner's default.
     pub reuse_query_fragments: Option<bool>,
 }
 

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__reuse_query_fragments_defaults_to_true.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__reuse_query_fragments_defaults_to_true.snap
@@ -1,0 +1,17 @@
+---
+source: router-bridge/src/planner.rs
+expression: "serde_json::to_string_pretty(&payload.data).unwrap()"
+---
+{
+  "queryPlan": {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Fetch",
+      "serviceName": "Subgraph1",
+      "variableUsages": [],
+      "operation": "{t{a1{...Selection}a2{...Selection}}}fragment Selection on A{x y}",
+      "operationKind": "query"
+    }
+  },
+  "formattedQueryPlan": "QueryPlan {\n  Fetch(service: \"Subgraph1\") {\n    {\n      t {\n        a1 {\n          ...Selection\n        }\n        a2 {\n          ...Selection\n        }\n      }\n    }\n    \n    fragment Selection on A {\n      x\n      y\n    }\n  },\n}"
+}

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__reuse_query_fragments_explicit_true.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__reuse_query_fragments_explicit_true.snap
@@ -1,0 +1,17 @@
+---
+source: router-bridge/src/planner.rs
+expression: "serde_json::to_string_pretty(&payload.data).unwrap()"
+---
+{
+  "queryPlan": {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Fetch",
+      "serviceName": "Subgraph1",
+      "variableUsages": [],
+      "operation": "{t{a1{...Selection}a2{...Selection}}}fragment Selection on A{x y}",
+      "operationKind": "query"
+    }
+  },
+  "formattedQueryPlan": "QueryPlan {\n  Fetch(service: \"Subgraph1\") {\n    {\n      t {\n        a1 {\n          ...Selection\n        }\n        a2 {\n          ...Selection\n        }\n      }\n    }\n    \n    fragment Selection on A {\n      x\n      y\n    }\n  },\n}"
+}

--- a/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__reuse_query_fragments_false.snap
+++ b/federation-2/router-bridge/src/snapshots/router_bridge__planner__tests__reuse_query_fragments_false.snap
@@ -1,0 +1,17 @@
+---
+source: router-bridge/src/planner.rs
+expression: "serde_json::to_string_pretty(&payload.data).unwrap()"
+---
+{
+  "queryPlan": {
+    "kind": "QueryPlan",
+    "node": {
+      "kind": "Fetch",
+      "serviceName": "Subgraph1",
+      "variableUsages": [],
+      "operation": "{t{a1{x y}a2{x y}}}",
+      "operationKind": "query"
+    }
+  },
+  "formattedQueryPlan": "QueryPlan {\n  Fetch(service: \"Subgraph1\") {\n    {\n      t {\n        a1 {\n          x\n          y\n        }\n        a2 {\n          x\n          y\n        }\n      }\n    }\n  },\n}"
+}

--- a/federation-2/router-bridge/src/testdata/query_reuse_query_fragments.graphql
+++ b/federation-2/router-bridge/src/testdata/query_reuse_query_fragments.graphql
@@ -1,0 +1,15 @@
+query {
+  t {
+    a1 {
+      ...Selection
+    }
+    a2 {
+      ...Selection
+    }
+  }
+}
+
+fragment Selection on A {
+  x
+  y
+}

--- a/federation-2/router-bridge/src/testdata/schema_reuse_query_fragments.graphql
+++ b/federation-2/router-bridge/src/testdata/schema_reuse_query_fragments.graphql
@@ -1,0 +1,60 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1)
+{
+  x: Int
+  y: Int
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1)
+{
+  a1: A
+  a2: A
+}


### PR DESCRIPTION
In JS, you can pass `reuseQueryFragments: false` to `new QueryPlanner`. This PR makes the same flag accessible via Rust.

The tests are based on the tests in `@apollo/query-planner`:

https://github.com/apollographql/federation/blob/8e130db16/query-planner-js/src/__tests__/buildPlan.test.ts#L3907-L3988