### PR TITLE
release: router-bridge@v0.4.0+v2.4.10

### DIFF
--- a/federation-2/Cargo.lock
+++ b/federation-2/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.3.2+v2.4.10"
+version = "0.4.0+v2.4.10"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/federation-2/router-bridge/Cargo.toml
+++ b/federation-2/router-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router-bridge"
-version = "0.3.2+v2.4.10"
+version = "0.4.0+v2.4.10"
 authors = ["Apollo <packages@apollographql.com>"]
 edition = "2018"
 description = "JavaScript bridge for the Apollo Router"


### PR DESCRIPTION
`router-bridge@v0.3.2+v2.4.10` contained a breaking change. The router won't compile without modifications so it must be yanked.

