### PR TITLE
Added remote SchemaSource type

### DIFF
--- a/apollo-federation-types/src/config/subgraph.rs
+++ b/apollo-federation-types/src/config/subgraph.rs
@@ -42,6 +42,10 @@ pub enum SchemaSource {
     File {
         file: Utf8PathBuf,
     },
+    Remote {
+        remote_url: Url,
+        headers: Option<HashMap<String, String>>,
+    },
     SubgraphIntrospection {
         subgraph_url: Url,
         introspection_headers: Option<HashMap<String, String>>,
@@ -57,6 +61,7 @@ pub enum SchemaSource {
 
 #[cfg(test)]
 mod test_schema_source {
+    use std::collections::HashMap;
     use crate::config::SchemaSource;
     use serde_yaml::from_str;
 
@@ -111,6 +116,23 @@ subgraph: my-subgraph
         let expected = SchemaSource::Subgraph {
             graphref: "my-graph@current".to_string(),
             subgraph: "my-subgraph".to_string(),
+        };
+        assert_eq!(source, expected);
+    }
+
+    #[test]
+    fn test_remote() {
+        let yaml = r#"
+remote_url: https://example.com/some/schema/v1.0.graphqls
+headers:
+    Authorization: ${env.AUTH_TOKEN}
+        "#;
+        let source: SchemaSource = from_str(yaml).unwrap();
+        let expected = SchemaSource::Remote {
+            remote_url: "https://example.com/some/schema/v1.0.graphqls".parse().unwrap(),
+            headers: Some(
+                HashMap::from([("Authorization".to_string(), "${env.AUTH_TOKEN}".to_string())])
+            )
         };
         assert_eq!(source, expected);
     }


### PR DESCRIPTION
Added remote schema source type of unblocking loading remote schema from any static servers (eg. nexus) in rover-cli. 