### PR TITLE
Set `supportedFeatures` appropriately when calling `Supergraph.build()`.

### DIFF
--- a/federation-2/router-bridge/js-src/api_schema.ts
+++ b/federation-2/router-bridge/js-src/api_schema.ts
@@ -6,6 +6,7 @@ import {
 } from "graphql";
 
 import { Supergraph } from "@apollo/federation-internals";
+import { ROUTER_SUPPORTED_SUPERGRAPH_FEATURES } from "./supported_features";
 
 export interface ApiSchemaOptions {
   graphqlValidation?: boolean;
@@ -31,7 +32,9 @@ export function apiSchema(
 
   try {
     // Now try to get the API schema
-    let supergraph = Supergraph.build(sdl);
+    let supergraph = Supergraph.build(sdl, {
+      supportedFeatures: ROUTER_SUPPORTED_SUPERGRAPH_FEATURES,
+    });
 
     let apiSchema = supergraph.apiSchema();
     schema = printSchema(apiSchema.toGraphQLJSSchema());

--- a/federation-2/router-bridge/js-src/plan.ts
+++ b/federation-2/router-bridge/js-src/plan.ts
@@ -26,6 +26,7 @@ import {
 } from "@apollo/utils.usagereporting";
 import { ReferencedFieldsForType } from "@apollo/usage-reporting-protobuf";
 import { QueryPlannerConfigExt } from "./types";
+import { ROUTER_SUPPORTED_SUPERGRAPH_FEATURES } from "./supported_features";
 
 const PARSE_FAILURE: string = "## GraphQLParseFailure\n";
 const PARSE_FAILURE_EXT_CODE: string = "GRAPHQL_PARSE_FAILED";
@@ -39,6 +40,7 @@ export type UsageReporting = {
   statsReportKey: string;
   referencedFieldsByType: ReferencedFieldsByType;
 };
+
 export interface ExecutionResultWithUsageReporting<T>
   extends ExecutionResult<T> {
   usageReporting: UsageReporting;
@@ -58,7 +60,9 @@ export class BridgeQueryPlanner {
     public readonly schemaString: string,
     public readonly options: QueryPlannerConfigExt
   ) {
-    this.supergraph = Supergraph.build(schemaString);
+    this.supergraph = Supergraph.build(schemaString, {
+      supportedFeatures: ROUTER_SUPPORTED_SUPERGRAPH_FEATURES,
+    });
     const apiSchema = this.supergraph.schema.toAPISchema();
     this.apiSchema = apiSchema.toGraphQLJSSchema({
       includeDefer: options.incrementalDelivery?.enableDefer,

--- a/federation-2/router-bridge/js-src/supported_features.ts
+++ b/federation-2/router-bridge/js-src/supported_features.ts
@@ -1,28 +1,28 @@
 import {
   AUTHENTICATED_VERSIONS,
   DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES,
-  FeatureVersion,
+  FeatureDefinition,
+  FeatureDefinitions,
   REQUIRES_SCOPES_VERSIONS,
 } from "@apollo/federation-internals";
 
-const authenticatedV01Feature = AUTHENTICATED_VERSIONS.find(
-  new FeatureVersion(0, 1)
-);
-if (!authenticatedV01Feature) {
-  throw Error(
-    "Federation package unexpectedly did not contain authenticated v0.1 spec."
-  );
-}
-const requiresScopesV01Feature = REQUIRES_SCOPES_VERSIONS.find(
-  new FeatureVersion(0, 1)
-);
-if (!requiresScopesV01Feature) {
-  throw new Error(
-    "Federation package unexpectedly did not contain requiresScopes v0.1 spec."
-  );
-}
 export const ROUTER_SUPPORTED_SUPERGRAPH_FEATURES: Set<string> = new Set(
   DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES
-)
-  .add(authenticatedV01Feature.toString())
-  .add(requiresScopesV01Feature.toString());
+);
+
+function addToRouterFeatures<T extends FeatureDefinition>(
+  definitions: FeatureDefinitions<T>
+) {
+  definitions.versions().forEach((version) => {
+    const feature = definitions.find(version);
+    if (!feature) {
+      throw Error(
+        `Federation package unexpectedly did not contain feature spec ${definitions.identity}/${version}`
+      );
+    }
+    ROUTER_SUPPORTED_SUPERGRAPH_FEATURES.add(feature.toString());
+  });
+}
+
+addToRouterFeatures(AUTHENTICATED_VERSIONS);
+addToRouterFeatures(REQUIRES_SCOPES_VERSIONS);

--- a/federation-2/router-bridge/js-src/supported_features.ts
+++ b/federation-2/router-bridge/js-src/supported_features.ts
@@ -21,7 +21,7 @@ if (!requiresScopesV01Feature) {
     "Federation package unexpectedly did not contain requiresScopes v0.1 spec."
   );
 }
-export const ROUTER_SUPPORTED_SUPERGRAPH_FEATURES: Set<String> = new Set(
+export const ROUTER_SUPPORTED_SUPERGRAPH_FEATURES: Set<string> = new Set(
   DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES
 )
   .add(authenticatedV01Feature.toString())

--- a/federation-2/router-bridge/js-src/supported_features.ts
+++ b/federation-2/router-bridge/js-src/supported_features.ts
@@ -1,0 +1,28 @@
+import {
+  AUTHENTICATED_VERSIONS,
+  DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES,
+  FeatureVersion,
+  REQUIRES_SCOPES_VERSIONS,
+} from "@apollo/federation-internals";
+
+const authenticatedV01Feature = AUTHENTICATED_VERSIONS.find(
+  new FeatureVersion(0, 1)
+);
+if (!authenticatedV01Feature) {
+  throw Error(
+    "Federation package unexpectedly did not contain authenticated v0.1 spec."
+  );
+}
+const requiresScopesV01Feature = REQUIRES_SCOPES_VERSIONS.find(
+  new FeatureVersion(0, 1)
+);
+if (!requiresScopesV01Feature) {
+  throw new Error(
+    "Federation package unexpectedly did not contain requiresScopes v0.1 spec."
+  );
+}
+export const ROUTER_SUPPORTED_SUPERGRAPH_FEATURES: Set<String> = new Set(
+  DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES
+)
+  .add(authenticatedV01Feature.toString())
+  .add(requiresScopesV01Feature.toString());


### PR DESCRIPTION
Router supports the `authenticated` v0.1 spec and the `requiresScopes` v0.1 spec, but these aren't included in the default specs used by `Supergraph.build()` (i.e. `DEFAULT_SUPPORTED_SUPERGRAPH_FEATURES`), so usages of these specs cause errors.

This PR changes the `supportedFeatures` passed to `Supergraph.build()` to include `'https://specs.apollo.dev/authenticated/v0.1'` and  `'https://specs.apollo.dev/requiresScopes/v0.1'` in addition to the default specs.