### PR TITLE
Allow harmonize to return a limited number of nodes

### DIFF
--- a/apollo-federation-types/src/build/error.rs
+++ b/apollo-federation-types/src/build/error.rs
@@ -273,7 +273,7 @@ mod tests {
     use super::{BuildError, BuildErrors};
 
     use serde_json::{json, Value};
-    use crate::build::{BuildErrorNode, BuildHint};
+    use crate::build::{BuildErrorNode};
 
     #[test]
     fn it_supports_iter() {

--- a/apollo-federation-types/src/build/error.rs
+++ b/apollo-federation-types/src/build/error.rs
@@ -92,7 +92,13 @@ impl BuildError {
         nodes: Option<Vec<BuildErrorNode>>,
         omitted_nodes_count: Option<u32>,
     ) -> BuildError {
-        BuildError::new(code, message, BuildErrorType::Composition, nodes, omitted_nodes_count)
+        BuildError::new(
+            code,
+            message,
+            BuildErrorType::Composition,
+            nodes,
+            omitted_nodes_count,
+        )
     }
 
     pub fn config_error(code: Option<String>, message: Option<String>) -> BuildError {
@@ -137,7 +143,9 @@ impl BuildError {
         self.nodes.clone()
     }
 
-    pub fn get_omitted_nodes_count(&self) -> Option<u32> { self.omitted_nodes_count.clone() }
+    pub fn get_omitted_nodes_count(&self) -> Option<u32> {
+        self.omitted_nodes_count.clone()
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -272,14 +280,19 @@ impl Error for BuildErrors {}
 mod tests {
     use super::{BuildError, BuildErrors};
 
+    use crate::build::BuildErrorNode;
     use serde_json::{json, Value};
-    use crate::build::{BuildErrorNode};
 
     #[test]
     fn it_supports_iter() {
         let build_errors: BuildErrors = vec![
             BuildError::composition_error(None, Some("wow".to_string()), None, None),
-            BuildError::composition_error(Some("BOO".to_string()), Some("boo".to_string()), None, None),
+            BuildError::composition_error(
+                Some("BOO".to_string()),
+                Some("boo".to_string()),
+                None,
+                None,
+            ),
         ]
         .into();
 
@@ -302,11 +315,26 @@ mod tests {
 
     #[test]
     fn it_can_serialize_some_build_errors() {
-        let error_node = BuildErrorNode { subgraph: Some("foo".to_string()), source: None, start: None, end: None };
+        let error_node = BuildErrorNode {
+            subgraph: Some("foo".to_string()),
+            source: None,
+            start: None,
+            end: None,
+        };
 
         let build_errors: BuildErrors = vec![
-            BuildError::composition_error(None, Some("wow".to_string()), Some(vec![error_node.clone()]), Some(1)),
-            BuildError::composition_error(Some("BOO".to_string()), Some("boo".to_string()), Some(vec![error_node.clone()]), Some(2)),
+            BuildError::composition_error(
+                None,
+                Some("wow".to_string()),
+                Some(vec![error_node.clone()]),
+                Some(1),
+            ),
+            BuildError::composition_error(
+                Some("BOO".to_string()),
+                Some("boo".to_string()),
+                Some(vec![error_node.clone()]),
+                Some(2),
+            ),
         ]
         .into();
 
@@ -358,7 +386,8 @@ mod tests {
         let actual_struct = serde_json::from_str(
             &json!({ "message": &msg, "code": &code, "type": "composition", "nodes": null, "omittedNodesCount": 12 }).to_string(),
         ).unwrap();
-        let expected_struct = BuildError::composition_error(Some(code.clone()), Some(msg.clone()), None, Some(12));
+        let expected_struct =
+            BuildError::composition_error(Some(code.clone()), Some(msg.clone()), None, Some(12));
         assert_eq!(expected_struct, actual_struct);
     }
 }

--- a/apollo-federation-types/src/build/error.rs
+++ b/apollo-federation-types/src/build/error.rs
@@ -144,7 +144,7 @@ impl BuildError {
     }
 
     pub fn get_omitted_nodes_count(&self) -> Option<u32> {
-        self.omitted_nodes_count.clone()
+        self.omitted_nodes_count
     }
 }
 

--- a/apollo-federation-types/src/build/error.rs
+++ b/apollo-federation-types/src/build/error.rs
@@ -330,7 +330,7 @@ mod tests {
                       "end": null
                   }
                 ],
-                "omitted_nodes_count": 1
+                "omittedNodesCount": 1
               },
               {
                 "message": "boo",
@@ -344,7 +344,7 @@ mod tests {
                       "end": null
                   }
                 ],
-                "omitted_nodes_count": 2
+                "omittedNodesCount": 2
               }
             ]
         });

--- a/apollo-federation-types/src/build/hint.rs
+++ b/apollo-federation-types/src/build/hint.rs
@@ -44,7 +44,7 @@ mod tests {
     fn it_can_serialize() {
         let msg = "hint".to_string();
         let code = "hintCode".to_string();
-        let expected_json = json!({ "message": &msg, "code": &code, "nodes": null });
+        let expected_json = json!({ "message": &msg, "code": &code, "nodes": null, "omittedNodesCount": null });
         let actual_json = serde_json::to_value(&BuildHint::new(msg, code, None, None)).unwrap();
         assert_eq!(expected_json, actual_json)
     }

--- a/apollo-federation-types/src/build/hint.rs
+++ b/apollo-federation-types/src/build/hint.rs
@@ -23,7 +23,12 @@ pub struct BuildHint {
 }
 
 impl BuildHint {
-    pub fn new(message: String, code: String, nodes: Option<Vec<BuildErrorNode>>, omitted_nodes_count: Option<u32>) -> Self {
+    pub fn new(
+        message: String,
+        code: String,
+        nodes: Option<Vec<BuildErrorNode>>,
+        omitted_nodes_count: Option<u32>,
+    ) -> Self {
         Self {
             message,
             code: Some(code),
@@ -44,7 +49,8 @@ mod tests {
     fn it_can_serialize() {
         let msg = "hint".to_string();
         let code = "hintCode".to_string();
-        let expected_json = json!({ "message": &msg, "code": &code, "nodes": null, "omittedNodesCount": null });
+        let expected_json =
+            json!({ "message": &msg, "code": &code, "nodes": null, "omittedNodesCount": null });
         let actual_json = serde_json::to_value(&BuildHint::new(msg, code, None, None)).unwrap();
         assert_eq!(expected_json, actual_json)
     }
@@ -54,7 +60,8 @@ mod tests {
         let msg = "hint".to_string();
         let code = "hintCode".to_string();
         let actual_struct = serde_json::from_str(
-            &json!({ "message": &msg, "code": &code, "nodes": null, "omittedNodesCount": 12 }).to_string(),
+            &json!({ "message": &msg, "code": &code, "nodes": null, "omittedNodesCount": 12 })
+                .to_string(),
         )
         .unwrap();
         let expected_struct = BuildHint::new(msg, code, None, Some(12));

--- a/apollo-federation-types/src/build/output.rs
+++ b/apollo-federation-types/src/build/output.rs
@@ -60,8 +60,8 @@ mod tests {
         let actual_json = serde_json::to_value(&BuildOutput::new_with_hints(
             sdl.to_string(),
             vec![
-                BuildHint::new(hint_one, code, None),
-                BuildHint::new(hint_two, code2, None),
+                BuildHint::new(hint_one, code, None, None),
+                BuildHint::new(hint_two, code2, None, None),
             ],
         ))
         .unwrap();
@@ -91,8 +91,8 @@ mod tests {
         let expected_struct = BuildOutput::new_with_hints(
             sdl,
             vec![
-                BuildHint::new(hint_one, code, None),
-                BuildHint::new(hint_two, code2, None),
+                BuildHint::new(hint_one, code, None, None),
+                BuildHint::new(hint_two, code2, None, None),
             ],
         );
 

--- a/apollo-federation-types/src/build/output.rs
+++ b/apollo-federation-types/src/build/output.rs
@@ -56,7 +56,7 @@ mod tests {
         let hint_two = "hint-two".to_string();
         let code = "code".to_string();
         let code2 = "code2".to_string();
-        let expected_json = json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one, "code": &code, "nodes": null}, {"message": &hint_two, "code": &code2, "nodes": null}]});
+        let expected_json = json!({"supergraphSdl": &sdl, "hints": [{"message": &hint_one, "code": &code, "nodes": null, "omittedNodesCount": null}, {"message": &hint_two, "code": &code2, "nodes": null, "omittedNodesCount": null}]});
         let actual_json = serde_json::to_value(&BuildOutput::new_with_hints(
             sdl.to_string(),
             vec![

--- a/federation-1/harmonizer/src/js_types.rs
+++ b/federation-1/harmonizer/src/js_types.rs
@@ -59,7 +59,7 @@ impl Display for CompositionError {
 
 impl From<CompositionError> for BuildError {
     fn from(input: CompositionError) -> Self {
-        Self::composition_error(input.code, input.message, input.nodes)
+        Self::composition_error(input.code, input.message, input.nodes, None)
     }
 }
 

--- a/federation-2/harmonizer/js-src/composition.ts
+++ b/federation-2/harmonizer/js-src/composition.ts
@@ -9,11 +9,13 @@ import {
 } from "./types";
 import { ERRORS } from "@apollo/federation-internals";
 
-const NODES_SIZE_LIMIT: number = 20;
+const DEFAULT_NODES_SIZE_LIMIT: number = Number.MAX_VALUE;
 
 export function composition(
   serviceList: { sdl: string; name: string; url?: string }[],
+  nodesLimit?: number | null
 ): CompositionResult {
+  let limit = nodesLimit || DEFAULT_NODES_SIZE_LIMIT;
   if (!serviceList || !Array.isArray(serviceList)) {
     throw new Error("Error in JS-Rust-land: serviceList missing or incorrect.");
   }
@@ -45,11 +47,11 @@ export function composition(
       // for issues that happen in all subgraphs and with a large amount of subgraphs,
       // only add nodes up to the limit to prevent massive responses
       // (OOM errors when going from js to rust)
-      if (composed_hint.nodes?.length >= NODES_SIZE_LIMIT) {
+      if (composed_hint.nodes?.length >= limit) {
         composed_hint.nodes
-          ?.slice(0, NODES_SIZE_LIMIT)
+          ?.slice(0, limit)
           .map((node) => nodes.push(getBuildErrorNode(node)));
-        omittedNodesCount = composed_hint.nodes?.length - NODES_SIZE_LIMIT;
+        omittedNodesCount = composed_hint.nodes?.length - limit;
       } else {
         composed_hint.nodes?.map((node) => nodes.push(getBuildErrorNode(node)));
       }
@@ -73,11 +75,11 @@ export function composition(
       // for issues that happen in all subgraphs and with a large amount of subgraphs,
       // only add nodes up to the limit to prevent massive responses
       // (OOM errors when going from js to rust)
-      if (err.nodes?.length >= NODES_SIZE_LIMIT) {
+      if (err.nodes?.length >= limit) {
         err.nodes
-          ?.slice(0, NODES_SIZE_LIMIT)
+          ?.slice(0, limit)
           .map((node) => nodes.push(getBuildErrorNode(node)));
-        omittedNodesCount = err.nodes?.length - NODES_SIZE_LIMIT;
+        omittedNodesCount = err.nodes?.length - limit;
       } else {
         err.nodes?.map((node) => nodes.push(getBuildErrorNode(node)));
       }

--- a/federation-2/harmonizer/js-src/do_compose.ts
+++ b/federation-2/harmonizer/js-src/do_compose.ts
@@ -10,12 +10,13 @@ declare let composition_bridge: { composition: typeof composition };
 
 declare let done: (compositionResult: CompositionResult) => void;
 declare let serviceList: { sdl: string; name: string; url?: string }[];
+declare let nodesLimit: number | null;
 
 try {
   // /**
   //  * @type {{ errors: Error[], supergraphSdl?: undefined, hints: undefined } | { errors?: undefined, supergraphSdl: string, hints: string }}
   //  */
-  const composed = composition_bridge.composition(serviceList);
+  const composed = composition_bridge.composition(serviceList, nodesLimit);
 
   done(composed);
 } catch (err) {

--- a/federation-2/harmonizer/js-src/types.ts
+++ b/federation-2/harmonizer/js-src/types.ts
@@ -6,6 +6,7 @@ export type CompositionError = {
   message?: string;
   code?: string;
   nodes: BuildErrorNode[];
+  omittedNodesCount: number;
 };
 
 export type BuildErrorNode = {
@@ -26,4 +27,5 @@ export type CompositionHint = {
   message: string;
   code: string;
   nodes: BuildErrorNode[];
+  omittedNodesCount: number;
 };

--- a/federation-2/harmonizer/src/js_types.rs
+++ b/federation-2/harmonizer/src/js_types.rs
@@ -18,6 +18,7 @@ use apollo_federation_types::build::{BuildError, BuildErrorNode};
 /// [`graphql-js']: https://npm.im/graphql
 /// [`GraphQLError`]: https://github.com/graphql/graphql-js/blob/3869211/src/error/GraphQLError.js#L18-L75
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct CompositionError {
     /// A human-readable description of the error that prevented composition.
     message: Option<String>,
@@ -29,6 +30,8 @@ pub(crate) struct CompositionError {
     code: Option<String>,
 
     nodes: Option<Vec<BuildErrorNode>>,
+
+    omitted_nodes_count: Option<u32>,
 }
 
 impl CompositionError {
@@ -38,6 +41,7 @@ impl CompositionError {
             extensions: None,
             code: None,
             nodes: None,
+            omitted_nodes_count: Some(u32::default()),
         }
     }
 }
@@ -59,7 +63,7 @@ impl Display for CompositionError {
 
 impl From<CompositionError> for BuildError {
     fn from(input: CompositionError) -> Self {
-        Self::composition_error(input.code, input.message, input.nodes)
+        Self::composition_error(input.code, input.message, input.nodes, input.omitted_nodes_count)
     }
 }
 

--- a/federation-2/harmonizer/src/js_types.rs
+++ b/federation-2/harmonizer/src/js_types.rs
@@ -63,7 +63,12 @@ impl Display for CompositionError {
 
 impl From<CompositionError> for BuildError {
     fn from(input: CompositionError) -> Self {
-        Self::composition_error(input.code, input.message, input.nodes, input.omitted_nodes_count)
+        Self::composition_error(
+            input.code,
+            input.message,
+            input.nodes,
+            input.omitted_nodes_count,
+        )
     }
 }
 

--- a/federation-2/harmonizer/src/lib.rs
+++ b/federation-2/harmonizer/src/lib.rs
@@ -44,6 +44,13 @@ use apollo_federation_types::build::{
 /// The `harmonize` function receives a [`Vec<SubgraphDefinition>`] and invokes JavaScript
 /// composition on it, either returning the successful output, or a list of error messages.
 pub fn harmonize(subgraph_definitions: Vec<SubgraphDefinition>) -> BuildResult {
+    return harmonize_limit(subgraph_definitions, None)
+}
+
+/// The `harmonize` function receives a [`Vec<SubgraphDefinition>`] and invokes JavaScript
+/// composition on it, either returning the successful output, or a list of error messages.
+/// `nodes_limit` limits the number of returns schema nodes to prevent OOM issues
+pub fn harmonize_limit(subgraph_definitions: Vec<SubgraphDefinition>, nodes_limit: Option<u32>) -> BuildResult {
     // The snapshot is created in the build_harmonizer.rs script and included in our binary image
     let buffer = include_bytes!(concat!(env!("OUT_DIR"), "/composition.snap"));
 
@@ -81,6 +88,14 @@ pub fn harmonize(subgraph_definitions: Vec<SubgraphDefinition>) -> BuildResult {
             deno_core::FastString::Owned(service_list_javascript.into()),
         )
         .expect("unable to evaluate service list in JavaScript runtime");
+
+    // store the nodes_limit variable in the nodesLimit variable
+    runtime
+        .execute_script(
+            "<set_nodes_limit>",
+            deno_core::FastString::Owned(format!("nodesLimit = {}", nodes_limit.map(|n| n.to_string()).unwrap_or("null".to_string())).into()),
+        )
+        .expect("unable to evaluate nodes limit in JavaScript runtime");
 
     // run the unmodified do_compose.js file, which expects `serviceList` to be set
     runtime

--- a/federation-2/harmonizer/src/lib.rs
+++ b/federation-2/harmonizer/src/lib.rs
@@ -44,13 +44,16 @@ use apollo_federation_types::build::{
 /// The `harmonize` function receives a [`Vec<SubgraphDefinition>`] and invokes JavaScript
 /// composition on it, either returning the successful output, or a list of error messages.
 pub fn harmonize(subgraph_definitions: Vec<SubgraphDefinition>) -> BuildResult {
-    return harmonize_limit(subgraph_definitions, None)
+    harmonize_limit(subgraph_definitions, None)
 }
 
 /// The `harmonize` function receives a [`Vec<SubgraphDefinition>`] and invokes JavaScript
 /// composition on it, either returning the successful output, or a list of error messages.
 /// `nodes_limit` limits the number of returns schema nodes to prevent OOM issues
-pub fn harmonize_limit(subgraph_definitions: Vec<SubgraphDefinition>, nodes_limit: Option<u32>) -> BuildResult {
+pub fn harmonize_limit(
+    subgraph_definitions: Vec<SubgraphDefinition>,
+    nodes_limit: Option<u32>,
+) -> BuildResult {
     // The snapshot is created in the build_harmonizer.rs script and included in our binary image
     let buffer = include_bytes!(concat!(env!("OUT_DIR"), "/composition.snap"));
 
@@ -93,7 +96,15 @@ pub fn harmonize_limit(subgraph_definitions: Vec<SubgraphDefinition>, nodes_limi
     runtime
         .execute_script(
             "<set_nodes_limit>",
-            deno_core::FastString::Owned(format!("nodesLimit = {}", nodes_limit.map(|n| n.to_string()).unwrap_or("null".to_string())).into()),
+            deno_core::FastString::Owned(
+                format!(
+                    "nodesLimit = {}",
+                    nodes_limit
+                        .map(|n| n.to_string())
+                        .unwrap_or("null".to_string())
+                )
+                .into(),
+            ),
         )
         .expect("unable to evaluate nodes limit in JavaScript runtime");
 


### PR DESCRIPTION
## Description

For our largest graph, running composition yields thousands of build hints and each build hint can contain hundreds of attached nodes (nodes are snippets of subgraph SDL that help with locating issues), leading to very high memory consumption (>10sGB) and can use all of the host physical memory.

## Investigation

Running composition using the `harmonize` function with dhat enabled; we can see that most allocations are done when deserializing json from v8 to rust ` serde_v8::de::to_utf8_fast`. On my M1 Mac this was taken right before the process was killed by the OS and was consuming 45GB of memory.

![Screenshot 2023-10-16 at 2 17 03 PM](https://github.com/apollographql/federation-rs/assets/1523863/333fdde7-7efb-411e-87a4-102253bf777a)

[dhat-heap-main.json](https://github.com/apollographql/federation-rs/files/12922166/dhat-heap-main.json)


## Fix/Proposal

In the spirit of keeping the library backward compatible, I added a `harmonize_limit()` function that takes an extra parameter that will limit the number of nodes returned in each build hint and/or build error. All nodes above that limit are omitted from the result and a flag `omitted_nodes_count` is set so the caller is aware some nodes have been omitted. 

If no `nodes_limit` value is passed it defaults to unlimited. The `harmonize` function defaults to unlimited to preserve backward compatibility.

Passing `nodes_limit=20` works for us for now, but one could argue there is limited additional insight past 20 nodes anyway and we could make it the default instead.

