### PR TITLE
ci: fix CMake install by explicitly using `cmake.install` on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,22 +38,22 @@ parameters:
 
 # The main workflows executed for federation-rs
 workflows:
-  lint:
-    jobs:
-      - xtask:
-          name: Lint
-          matrix:
-            parameters:
-              platform: [amd_centos]
-              rust_channel: [stable]
-              command: [lint]
+  # lint:
+  #   jobs:
+  #     - xtask:
+  #         name: Lint
+  #         matrix:
+  #           parameters:
+  #             platform: [amd_centos]
+  #             rust_channel: [stable]
+  #             command: [lint]
   test:
     jobs:
       - xtask:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
+              platform: [amd_windows]
               rust_channel: [stable]
               command: [test]
 
@@ -63,7 +63,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
+              platform: [amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -72,7 +72,7 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
+              platform: [amd_windows]
               rust_channel: [stable]
               command: [package]
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  choco install cmake.portable -y
+                  choco install cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=User'
                   exit $LASTEXITCODE
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,54 +57,54 @@ workflows:
               rust_channel: [stable]
               command: [test]
 
-  # release:
-  #   jobs:
-  #     - xtask:
-  #         name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
-  #         matrix:
-  #           parameters:
-  #             platform: [amd_windows]
-  #             rust_channel: [stable]
-  #             command: [test]
-  #         <<: *any_release
+  release:
+    jobs:
+      - xtask:
+          name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
+          matrix:
+            parameters:
+              platform: [amd_windows]
+              rust_channel: [stable]
+              command: [test]
+          <<: *any_release
 
-  #     - xtask:
-  #         name: Build and bundle release artifacts (<< matrix.platform >>)
-  #         matrix:
-  #           parameters:
-  #             platform: [amd_windows]
-  #             rust_channel: [stable]
-  #             command: [package]
-  #         requires:
-  #           - "Run cargo tests (stable rust on amd_centos)"
-  #           - "Run cargo tests (stable rust on arm_ubuntu)"
-  #           - "Run cargo tests (stable rust on amd_macos)"
-  #           - "Run cargo tests (stable rust on amd_windows)"
-  #         <<: *composition_release
+      - xtask:
+          name: Build and bundle release artifacts (<< matrix.platform >>)
+          matrix:
+            parameters:
+              platform: [amd_windows]
+              rust_channel: [stable]
+              command: [package]
+          requires:
+            - "Run cargo tests (stable rust on amd_centos)"
+            - "Run cargo tests (stable rust on arm_ubuntu)"
+            - "Run cargo tests (stable rust on amd_macos)"
+            - "Run cargo tests (stable rust on amd_windows)"
+          <<: *composition_release
 
-  #     - publish_release:
-  #         name: Publish to crates.io and create a GitHub release
-  #         matrix:
-  #           parameters:
-  #             platform: [minimal_linux]
-  #         requires:
-  #           - "Build and bundle release artifacts (amd_centos)"
-  #           - "Build and bundle release artifacts (arm_ubuntu)"
-  #           - "Build and bundle release artifacts (amd_macos)"
-  #           - "Build and bundle release artifacts (amd_windows)"
-  #         <<: *composition_release
+      - publish_release:
+          name: Publish to crates.io and create a GitHub release
+          matrix:
+            parameters:
+              platform: [minimal_linux]
+          requires:
+            - "Build and bundle release artifacts (amd_centos)"
+            - "Build and bundle release artifacts (arm_ubuntu)"
+            - "Build and bundle release artifacts (amd_macos)"
+            - "Build and bundle release artifacts (amd_windows)"
+          <<: *composition_release
 
-  #     - publish_release:
-  #         name: Publish to crates.io
-  #         matrix:
-  #           parameters:
-  #             platform: [minimal_linux]
-  #         requires:
-  #           - "Run cargo tests (stable rust on amd_centos)"
-  #           - "Run cargo tests (stable rust on arm_ubuntu)"
-  #           - "Run cargo tests (stable rust on amd_macos)"
-  #           - "Run cargo tests (stable rust on amd_windows)"
-  #         <<: *crate_release
+      - publish_release:
+          name: Publish to crates.io
+          matrix:
+            parameters:
+              platform: [minimal_linux]
+          requires:
+            - "Run cargo tests (stable rust on amd_centos)"
+            - "Run cargo tests (stable rust on arm_ubuntu)"
+            - "Run cargo tests (stable rust on amd_macos)"
+            - "Run cargo tests (stable rust on amd_windows)"
+          <<: *crate_release
 
   security-scans:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,7 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  choco install chocolatey -y
+                  choco install chocolatey --version 2.2.2 -y
                   choco install cmake -y
                   [Environment]::SetEnvironmentVariable("Path",  'C:\Program Files\CMake\bin;' + $env:Path, [System.EnvironmentVariableTarget]::User)
                   exit $LASTEXITCODE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,9 +336,7 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  choco install chocolatey --version 2.2.2 -y
-                  choco install cmake -y
-                  [Environment]::SetEnvironmentVariable("Path",  'C:\Program Files\CMake\bin;' + $env:Path, [System.EnvironmentVariableTarget]::User)
+                  choco install cmake.portable -y
                   exit $LASTEXITCODE
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,22 +38,22 @@ parameters:
 
 # The main workflows executed for federation-rs
 workflows:
-  # lint:
-  #   jobs:
-  #     - xtask:
-  #         name: Lint
-  #         matrix:
-  #           parameters:
-  #             platform: [amd_centos]
-  #             rust_channel: [stable]
-  #             command: [lint]
+  lint:
+    jobs:
+      - xtask:
+          name: Lint
+          matrix:
+            parameters:
+              platform: [amd_centos]
+              rust_channel: [stable]
+              command: [lint]
   test:
     jobs:
       - xtask:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
 
@@ -63,7 +63,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -72,7 +72,7 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ commands:
                 name: Install gcc
                 command: yum -y install perl-core gcc
             - run:
-                name: Install cmake
+                name: Install CMake
                 command: |
                   cd /usr/local/src
                   curl -LO https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.linux_cmake_version >>/cmake-<< pipeline.parameters.linux_cmake_version >>-linux-x86_64.tar.gz
@@ -269,7 +269,7 @@ commands:
                   brew install curl
                   echo 'export PATH="/usr/local/opt/curl/bin:$PATH"' >> $BASH_ENV
             - run:
-                name: Install cmake
+                name: Install CMake
                 command: |
                   brew install cmake
 
@@ -336,6 +336,7 @@ commands:
             - run:
                 name: Install CMake
                 command: |
+                  choco install chocolatey -y
                   choco install cmake -y
                   [Environment]::SetEnvironmentVariable("Path",  'C:\Program Files\CMake\bin;' + $env:Path, [System.EnvironmentVariableTarget]::User)
                   exit $LASTEXITCODE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,54 +57,54 @@ workflows:
               rust_channel: [stable]
               command: [test]
 
-  release:
-    jobs:
-      - xtask:
-          name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
-          matrix:
-            parameters:
-              platform: [amd_windows]
-              rust_channel: [stable]
-              command: [test]
-          <<: *any_release
+  # release:
+  #   jobs:
+  #     - xtask:
+  #         name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
+  #         matrix:
+  #           parameters:
+  #             platform: [amd_windows]
+  #             rust_channel: [stable]
+  #             command: [test]
+  #         <<: *any_release
 
-      - xtask:
-          name: Build and bundle release artifacts (<< matrix.platform >>)
-          matrix:
-            parameters:
-              platform: [amd_windows]
-              rust_channel: [stable]
-              command: [package]
-          requires:
-            - "Run cargo tests (stable rust on amd_centos)"
-            - "Run cargo tests (stable rust on arm_ubuntu)"
-            - "Run cargo tests (stable rust on amd_macos)"
-            - "Run cargo tests (stable rust on amd_windows)"
-          <<: *composition_release
+  #     - xtask:
+  #         name: Build and bundle release artifacts (<< matrix.platform >>)
+  #         matrix:
+  #           parameters:
+  #             platform: [amd_windows]
+  #             rust_channel: [stable]
+  #             command: [package]
+  #         requires:
+  #           - "Run cargo tests (stable rust on amd_centos)"
+  #           - "Run cargo tests (stable rust on arm_ubuntu)"
+  #           - "Run cargo tests (stable rust on amd_macos)"
+  #           - "Run cargo tests (stable rust on amd_windows)"
+  #         <<: *composition_release
 
-      - publish_release:
-          name: Publish to crates.io and create a GitHub release
-          matrix:
-            parameters:
-              platform: [minimal_linux]
-          requires:
-            - "Build and bundle release artifacts (amd_centos)"
-            - "Build and bundle release artifacts (arm_ubuntu)"
-            - "Build and bundle release artifacts (amd_macos)"
-            - "Build and bundle release artifacts (amd_windows)"
-          <<: *composition_release
+  #     - publish_release:
+  #         name: Publish to crates.io and create a GitHub release
+  #         matrix:
+  #           parameters:
+  #             platform: [minimal_linux]
+  #         requires:
+  #           - "Build and bundle release artifacts (amd_centos)"
+  #           - "Build and bundle release artifacts (arm_ubuntu)"
+  #           - "Build and bundle release artifacts (amd_macos)"
+  #           - "Build and bundle release artifacts (amd_windows)"
+  #         <<: *composition_release
 
-      - publish_release:
-          name: Publish to crates.io
-          matrix:
-            parameters:
-              platform: [minimal_linux]
-          requires:
-            - "Run cargo tests (stable rust on amd_centos)"
-            - "Run cargo tests (stable rust on arm_ubuntu)"
-            - "Run cargo tests (stable rust on amd_macos)"
-            - "Run cargo tests (stable rust on amd_windows)"
-          <<: *crate_release
+  #     - publish_release:
+  #         name: Publish to crates.io
+  #         matrix:
+  #           parameters:
+  #             platform: [minimal_linux]
+  #         requires:
+  #           - "Run cargo tests (stable rust on amd_centos)"
+  #           - "Run cargo tests (stable rust on arm_ubuntu)"
+  #           - "Run cargo tests (stable rust on amd_macos)"
+  #           - "Run cargo tests (stable rust on amd_windows)"
+  #         <<: *crate_release
 
   security-scans:
     jobs:


### PR DESCRIPTION
I can't explain why, but `choco install cmake -y` appears to no longer work, as the `cmake.install` package can't be found. I tried pinning to an older version on a previous branch, and in this branch I tried to update chocolatey itself as well, but it keeps failing. I thought it might be a networking configuration issue, but it turns out targeting `cmake.install` directly instead of through the metapackage works.

I'd propose just using `cmake.install` at least for now. As a side benefit, there is a command line flag to automatically configure the PATH, so we don't need to do it separately.