### PR TITLE
start router-bridge without snapshots on OSX x86_64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
             - "Run cargo tests (stable rust on amd_centos)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
-            - "Run cargo tests (stable rust on arm_macos)
+            - "Run cargo tests (stable rust on arm_macos)"
             - "Run cargo tests (stable rust on amd_windows)"
           <<: *crate_release
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
 
@@ -63,7 +63,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -72,13 +72,14 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
           requires:
             - "Run cargo tests (stable rust on amd_centos)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
+            - "Run cargo tests (stable rust on arm_macos)"
             - "Run cargo tests (stable rust on amd_windows)"
           <<: *composition_release
 
@@ -91,6 +92,7 @@ workflows:
             - "Build and bundle release artifacts (amd_centos)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_macos)"
+            - "Build and bundle release artifacts (arm_macos)"
             - "Build and bundle release artifacts (amd_windows)"
           <<: *composition_release
 
@@ -103,6 +105,7 @@ workflows:
             - "Run cargo tests (stable rust on amd_centos)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
+            - "Run cargo tests (stable rust on arm_macos)
             - "Run cargo tests (stable rust on amd_windows)"
           <<: *crate_release
 
@@ -188,6 +191,16 @@ executors:
       APPLE_USERNAME: "opensource@apollographql.com"
       MACOS_PRIMARY_BUNDLE_ID: com.apollographql.supergraph
 
+  arm_macos: &arm_macos_executor
+    macos:
+      xcode: "14.2"
+    resource_class: macos.m1.medium.gen1
+    environment:
+      XTASK_TARGET: "aarch64-apple-darwin"
+      APPLE_TEAM_ID: "YQK948L752"
+      APPLE_USERNAME: "opensource@apollographql.com"
+      MACOS_PRIMARY_BUNDLE_ID: com.apollographql.supergraph
+
   amd_windows: &amd_windows_executor
     machine:
       image: 'windows-server-2019-vs2019:2022.08.1'
@@ -257,6 +270,7 @@ commands:
           condition:
             or:
               - equal: [ *amd_macos_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Skip homebrew update

--- a/federation-2/router-bridge/build.rs
+++ b/federation-2/router-bridge/build.rs
@@ -66,7 +66,7 @@ fn update_bridge(current_dir: &Path) {
         .success());
 }
 
-#[cfg(feature = "docs_rs")]
+#[cfg(any(feature = "docs_rs", all(target_os = "macos", target_arch = "x86_64")))]
 fn create_snapshot(out_dir: &Path) {
     // If we're building on docs.rs we just create
     // an empty snapshot file and return, because `rusty_v8`
@@ -74,7 +74,7 @@ fn create_snapshot(out_dir: &Path) {
     std::fs::write(out_dir.join("query_runtime.snap"), []).unwrap();
 }
 
-#[cfg(not(feature = "docs_rs"))]
+#[cfg(not(any(feature = "docs_rs", all(target_os = "macos", target_arch = "x86_64"))))]
 fn create_snapshot(out_dir: &Path) {
     use deno_core::{JsRuntimeForSnapshot, RuntimeOptions};
     use std::fs::{read_to_string, File};


### PR DESCRIPTION
Soon the OSX x86_64 workers will not be available on CircleCI, so we need a way to cross compile from OSX ARM, but it will fail if we use snapshots.
As a workaround with a tradeoff on startup performance, we deactivate snapshots on OSX x86_64 to allow cross compilation