### PR TITLE
Include Git branch in CircleCI cache keys and bump key version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,18 +416,26 @@ commands:
         type: string
         default: ./
     steps:
-      - restore_cache:
-          keys:
-            - &target-cache-key rust-target-v3-<< parameters.platform >>-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+      # After burning two release versions due to caching misbehavior, we've
+      # decided to disable target/ caching for now, since this repository
+      # publishes builds relatively infrequently, and correctness is much more
+      # important than build speed. If build speed does become a problem in the
+      # future, it should be safe to uncomment the restore_cache and save_cache
+      # steps below, since we bumped v2 to v3 and added {{ .Branch }} in PR #476
+      # but never published anything using these rules.
+
+      # - restore_cache:
+      #     keys:
+      #       - &target-cache-key rust-target-v3-<< parameters.platform >>-{{ .Branch }}-{{ checksum "Cargo.lock" }}
 
       - run:
           command: cargo xtask << parameters.command >> << parameters.options >>
           working_directory: << parameters.working_directory >>
 
-      - save_cache:
-          key: *target-cache-key
-          paths:
-            - target/
+      # - save_cache:
+      #     key: *target-cache-key
+      #     paths:
+      #       - target/
 
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,14 +418,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+            - &target-cache-key rust-target-v3-<< parameters.platform >>-{{ .Branch }}-{{ checksum "Cargo.lock" }}
 
       - run:
           command: cargo xtask << parameters.command >> << parameters.options >>
           working_directory: << parameters.working_directory >>
 
       - save_cache:
-          key: rust-target-v2-<< parameters.platform >>-{{ checksum "Cargo.lock" }}
+          key: *target-cache-key
           paths:
             - target/
 


### PR DESCRIPTION
This should resolve an issue affecting the 2.7.5 release, where an old `federation-2/target/` cache was restored from an unrelated PR branch build (because `Cargo.lock` was the same), causing the compiled `supergraph` binary to call `op_composition_result` with a string rather than an object in some cases, triggering a panic on the Rust side.

I would have liked to disable this caching completely when publishing an official release, to prioritize correctness over build speed, but it doesn't seem like conditional caching is supported by CircleCI: https://circleci.com/docs/caching/#clearing-cache

We could potentially run `cargo clean` conditionally for release builds, after `restore_cache` (thereby throwing away the cache), but that doesn't seem ideal. Open to ideas!