### PR TITLE
Revert Rust version from 1.78.0 to 1.76.0 via `rustup` in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,11 @@ commands:
             - run:
                 name: Adds rust target
                 command: rustup target add $XTASK_TARGET
+            - run:
+                name: Set specific rust version
+                command: |
+                  rustup install 1.76.0
+                  rustup default 1.76.0
       - when:
           condition:
             equal: [ *amd_windows_executor, << parameters.platform >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,8 @@ commands:
                 name: Adds rust target
                 command: rustup target add $XTASK_TARGET
             - run:
-                name: Set specific rust version
+                name: Set default rustc version
+                # Should match the version pinned in rust-toolchain.toml
                 command: |
                   rustup install 1.76.0
                   rustup default 1.76.0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+# renovate-automation: rustc version
+channel = "1.76.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Another attempt to fix the `harmonizer` bug described in https://github.com/apollographql/federation-rs/pull/479#issuecomment-2110342100 and https://github.com/apollographql/federation-rs/pull/476#issuecomment-2101220771.