### PR TITLE
Avoid deleting all Git tags before pushing tags

### DIFF
--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -48,19 +48,6 @@ impl GitRunner {
         self.exec(&["fetch", "--tags", "--force"])
     }
 
-    // updates the remote tags we know about,
-    // overwriting any local tags,
-    // and then returns all current local git tags
-    pub(crate) fn get_tags(&self) -> Result<Vec<String>> {
-        self.fetch_remote_tags()?;
-        Ok(self
-            .exec(&["tag"])?
-            .stdout
-            .lines()
-            .map(|s| s.to_string())
-            .collect())
-    }
-
     // gets the current tags that point to HEAD
     pub(crate) fn get_head_tags(&self) -> Result<Vec<String>> {
         self.fetch_remote_tags()?;

--- a/xtask/src/tools/git.rs
+++ b/xtask/src/tools/git.rs
@@ -94,12 +94,10 @@ impl GitRunner {
     // takes a PackageTag and kicks off a release in CircleCI
     pub(crate) fn tag_release(&self, package_tag: &PackageTag, dry_run: bool) -> Result<()> {
         if !dry_run {
-            // create all the git tags we need from the PackageTag
+            // create all the git tags we need from the PackageTag, and push up
+            // only the tags we created here
             for tag in package_tag.all_tags() {
                 self.exec(&["tag", "-a", &tag, "-m", &tag]).context("If you want to re-publish this version, first delete the tag in GitHub at https://github.com/apollographql/federation-rs/current_git_tags")?;
-            }
-            // push up _only_ the tags that we just created
-            for tag in package_tag.all_tags() {
                 // Fully qualify the tag name to avoid ambiguity with branches
                 let refs_tags_tag = format!("refs/tags/{}", &tag);
                 self.exec(&["push", "origin", refs_tags_tag.as_str(), "--no-verify"])?;


### PR DESCRIPTION
I don't understand why the original author of this code thought it was important to delete all local tags, but that process now takes a considerable amount of time (to delete 359 tags) and is unnecessary. We can just push specific tags instead of using the `git push --tags` command.

The `git pull` command requires a remote tracking branch to be set. Since this is not a guaranteed condition, it's better to skip the unnecessary `git pull` command and assume we're already up-to-date before the `tag_release` function is called.