### PR TITLE
allow router-bridge releases independently of federation updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           cargo set-version $NEW_VERSION -p router-bridge
           cargo build -p router-bridge
           cd router-bridge
-          npm version "$VERSION"
+          npm version --allow-same-version "$VERSION"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
We sometimes need to publish a new router-bridge version without a federation upgrade, so the release action should not fail if we keep the same federation version