### PR TITLE
Derive Eq, PartialEq for SupergraphConfig and SubgraphConfig

### DIFF
--- a/apollo-federation-types/src/config/subgraph.rs
+++ b/apollo-federation-types/src/config/subgraph.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use url::Url;
 
 /// Config for a single [subgraph](https://www.apollographql.com/docs/federation/subgraphs/)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SubgraphConfig {
     /// The routing URL for the subgraph.
     /// This will appear in supergraph SDL and

--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, fs};
 
 /// The configuration for a single supergraph
 /// composed of multiple subgraphs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SupergraphConfig {
     // Store config in a BTreeMap, as HashMap is non-deterministic.
     subgraphs: BTreeMap<String, SubgraphConfig>,


### PR DESCRIPTION
Helps in solving for https://github.com/apollographql/rover/issues/480

In order to use `SupergraphConfig` as child element of [RoverOutput](https://github.com/apollographql/rover/blob/main/src/command/output.rs#L42) to produce yaml or json, we would need these types to be `Eq + PartialEq`.