### PR TITLE
Add general constructor for SupergraphConfig

### DIFF
--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -20,6 +20,16 @@ pub struct SupergraphConfig {
 }
 
 impl SupergraphConfig {
+    /// Creates a new SupergraphConfig
+    pub fn new(
+        subgraphs: BTreeMap<String, SubgraphConfig>,
+        federation_version: Option<FederationVersion>,
+    ) -> SupergraphConfig {
+        SupergraphConfig {
+            subgraphs,
+            federation_version,
+        }
+    }
     /// Create a new SupergraphConfig from a YAML string in memory.
     pub fn new_from_yaml(yaml: &str) -> ConfigResult<SupergraphConfig> {
         let parsed_config: SupergraphConfig =


### PR DESCRIPTION
This allows us to create a `SupergraphConfig` using the same types as its internal properties in order to support building this object from non-serialized sources.