### PR TITLE
Add the capability to increase harmonizer heap size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml_edit",
+ "tracing",
  "which",
 ]
 

--- a/harmonizer/Cargo.toml
+++ b/harmonizer/Cargo.toml
@@ -25,6 +25,7 @@ apollo-federation-types = { version = "0.11.0", path = "../apollo-federation-typ
 deno_core = "0.200.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1.33"
 
 [dev-dependencies]
 insta = "1.34.0"


### PR DESCRIPTION
## Description 
For large to very graphs, it is possible for deno v8 to run out of memory with the default settings. For us, it happens around `1400MB` of heap (I wasn't able to find the default v8 heap size)

Similar to the query planner, this PR vows to allow the harmonizer to grow up to a specified limit using env variables.

The error:
```
    <--- Last few GCs --->
    
    [48487:0x135078000]    51001 ms: Scavenge 1396.0 (1426.0) -> 1394.0 (1426.0) MB, 1.25 / 0.00 ms  (average mu = 0.211, current mu = 0.205) allocation failure; 
    [48487:0x135078000]    51004 ms: Scavenge 1396.0 (1426.0) -> 1394.1 (1426.0) MB, 1.21 / 0.00 ms  (average mu = 0.211, current mu = 0.205) allocation failure; 
    [48487:0x135078000]    51006 ms: Scavenge 1396.0 (1426.0) -> 1394.0 (1430.0) MB, 1.12 / 0.00 ms  (average mu = 0.211, current mu = 0.205) allocation failure; 
    
    
    <--- JS stacktrace --->
    
    
    #
    # Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit
    #
    
```