### PR TITLE
Add a warning about the stability of connectors

### DIFF
--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -129,7 +129,7 @@ pub trait HybridComposition {
                         })
                         .chain(once(Issue {
                             code: "EXPERIMENTAL_FEATURE".to_string(),
-                            message: "Connectors are an experimental feature. Breaking changes are likely to occur in future versions of composition.".to_string(),
+                            message: "Connectors are an experimental feature. Breaking changes are likely to occur in future versions.".to_string(),
                             locations: vec![],
                             severity: Severity::Warning,
                         })),

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -117,15 +117,22 @@ pub trait HybridComposition {
                 self.update_supergraph_sdl(raw_sdl);
                 let satisfiability_result = self.validate_satisfiability().await;
                 self.add_issues(
-                    satisfiability_result_into_issues(satisfiability_result).map(|mut issue| {
-                        for (service_name, connector) in &connectors_by_service_name {
-                            issue.message = issue.message.replace(
-                                service_name.as_str(),
-                                connector.id.subgraph_name.as_str(),
-                            );
-                        }
-                        issue
-                    }),
+                    satisfiability_result_into_issues(satisfiability_result)
+                        .map(|mut issue| {
+                            for (service_name, connector) in &connectors_by_service_name {
+                                issue.message = issue.message.replace(
+                                    service_name.as_str(),
+                                    connector.id.subgraph_name.as_str(),
+                                );
+                            }
+                            issue
+                        })
+                        .chain(once(Issue {
+                            code: "EXPERIMENTAL_FEATURE".to_string(),
+                            message: "Connectors are an experimental feature. Breaking changes are likely to occur in future versions of composition.".to_string(),
+                            locations: vec![],
+                            severity: Severity::Warning,
+                        })),
                 );
             }
             ExpansionResult::Unchanged => {


### PR DESCRIPTION
Addresses one of the concerns for landing connectors features on various `main` branches. Currently appears like this in Rover:

![Screenshot 2024-06-26 at 3 34 33 PM](https://github.com/apollographql/federation-rs/assets/142844950/0f7a66cb-d427-4137-b792-492e6d2a500d)

<!-- [CNN-220] -->


[CNN-220]: https://apollographql.atlassian.net/browse/CNN-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ