### PR TITLE
Default `CompositionHint.nodes` to an empty `Vec` when `undefined`

### DIFF
--- a/apollo-federation-types/src/javascript/mod.rs
+++ b/apollo-federation-types/src/javascript/mod.rs
@@ -30,6 +30,7 @@ pub struct SatisfiabilityResult {
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CompositionHint {
     pub message: String,
+    #[serde(default)]
     pub nodes: Vec<SubgraphASTNode>,
     pub definition: HintCodeDefinition,
 }


### PR DESCRIPTION
Follow-up to #519