### PR TITLE
preserve original supergraph

### DIFF
--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -122,6 +122,7 @@ pub trait HybridComposition {
                 },
                 ..
             } => {
+                let original_supergraph_sdl = supergraph_sdl.to_string();
                 self.update_supergraph_sdl(raw_sdl);
                 let satisfiability_result = self.validate_satisfiability().await;
                 self.add_issues(
@@ -142,6 +143,7 @@ pub trait HybridComposition {
                             severity: Severity::Warning,
                         })),
                 );
+                self.update_supergraph_sdl(original_supergraph_sdl);
             }
             ExpansionResult::Unchanged => {
                 let satisfiability_result = self.validate_satisfiability().await;


### PR DESCRIPTION
this change resets the supergraph so that the expanded one is not returned at the end of composition