### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "harmonizer"
-version = "2.8.2"
+version = "2.8.3-beta.0"
 dependencies = [
  "apollo-federation-types",
  "deno_core",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "supergraph"
-version = "2.8.2"
+version = "2.8.3-beta.0"
 dependencies = [
  "apollo-federation-types",
  "camino",


### PR DESCRIPTION
The [auto-filed harmonizer PR](https://github.com/apollographql/federation-rs/pull/527) for `2.8.3-beta.0` didn't update the Cargo lockfile (it looks like we had this issue before, and we [resolved](https://github.com/apollographql/federation-rs/pull/508) it via manually bumping the lockfile and triggering a release).