### PR TITLE
update amd_macos for cross compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,12 +184,12 @@ executors:
   amd_macos: &amd_macos_executor
     macos:
       xcode: "14.2"
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.large.gen1
     environment:
       XTASK_TARGET: "x86_64-apple-darwin"
+      RUSTUP_TARGET: "x86_64-apple-darwin" # cross-compile, because there are no native x86 macos runners
       APPLE_TEAM_ID: "YQK948L752"
       APPLE_USERNAME: "opensource@apollographql.com"
-      MACOS_PRIMARY_BUNDLE_ID: com.apollographql.supergraph
 
   arm_macos: &arm_macos_executor
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ executors:
       RUSTUP_TARGET: "x86_64-apple-darwin" # cross-compile, because there are no native x86 macos runners
       APPLE_TEAM_ID: "YQK948L752"
       APPLE_USERNAME: "opensource@apollographql.com"
+      MACOS_PRIMARY_BUNDLE_ID: com.apollographql.supergraph
 
   arm_macos: &arm_macos_executor
     macos:


### PR DESCRIPTION
Since CircleCI no longer supports intel mac agents, use the apple silicon and cross compile