### PR TITLE
Add function to check for macOS support in Federation Versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "assert_fs",
  "camino",
  "log",
+ "rstest",
  "semver 1.0.17",
  "serde",
  "serde_json",
@@ -539,7 +540,7 @@ dependencies = [
  "lazy-regex",
  "once_cell",
  "pmutil",
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -796,6 +797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +836,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -870,7 +883,7 @@ dependencies = [
  "semver 1.0.17",
  "serde",
  "serde_json",
- "toml_edit",
+ "toml_edit 0.19.9",
  "tracing",
  "which",
 ]
@@ -1414,7 +1427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.9",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -1574,6 +1596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "router-bridge"
 version = "0.5.28+v2.8.2"
 dependencies = [
@@ -1598,6 +1626,36 @@ dependencies = [
  "tracing",
  "tracing-test",
  "which",
+]
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.0",
+ "syn 2.0.48",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2139,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 
 [[package]]
 name = "toml_edit"
@@ -2151,7 +2209,18 @@ checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
 dependencies = [
  "indexmap 1.9.2",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.6",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2742,6 +2811,15 @@ name = "winnow"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -35,5 +35,6 @@ serde_json = {version = "1", optional = true}
 
 [dev-dependencies]
 assert_fs = "1"
+rstest = "0.21.0"
 serde_json = "1"
 serde_yaml = "0.8"

--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -127,8 +127,8 @@ impl FederationVersion {
             if self.is_latest() {
                 supports_arm = true;
             } else if let Some(exact) = self.get_exact() {
-                    // v2.7.1 is the earliest version published with aarch64 support for macOS
-                    supports_arm = exact.ge(&Version::parse("2.7.1").unwrap())
+                    // v2.7.3 is the earliest version published with aarch64 support for macOS
+                    supports_arm = exact.ge(&Version::parse("2.7.3").unwrap())
             }
         }
         supports_arm
@@ -314,8 +314,8 @@ mod test_federation_version {
     #[case::fed1_latest(FederationVersion::LatestFedOne, false)]
     #[case::fed1_unsupported(FederationVersion::ExactFedOne("0.37.2".parse().unwrap()), false)]
     #[case::fed2_latest(FederationVersion::LatestFedTwo, true)]
-    #[case::fed2_supported(FederationVersion::ExactFedTwo("2.7.3".parse().unwrap()), true)]
-    #[case::fed2_supported_boundary(FederationVersion::ExactFedTwo("2.7.1".parse().unwrap()), true)]
+    #[case::fed2_supported(FederationVersion::ExactFedTwo("2.8.1".parse().unwrap()), true)]
+    #[case::fed2_supported_boundary(FederationVersion::ExactFedTwo("2.7.3".parse().unwrap()), true)]
     #[case::fed2_unsupported(FederationVersion::ExactFedTwo("2.6.5".parse().unwrap()), false)]
     fn test_supports_arm_macos(#[case] version: FederationVersion, #[case] expected: bool) {
         assert_eq!(version.supports_arm_macos(), expected)

--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -121,7 +121,18 @@ impl FederationVersion {
     }
 
     pub fn supports_arm_macos(&self) -> bool {
-        return false
+        let mut supports_arm = false;
+        if self.is_fed_two() {
+            if self.is_latest() {
+                supports_arm = true;
+            }
+            else {
+                if let Some(exact) = self.get_exact() {
+                    supports_arm = exact.ge(&Version::parse("2.7.1").unwrap())
+                }
+            }
+        }
+        supports_arm
     }
 }
 
@@ -301,5 +312,19 @@ mod test_federation_version {
         #[case] expected: bool
     ) {
         assert_eq!(version.supports_arm_linux(), expected)
+    }
+
+    #[rstest]
+    #[case::fed1_latest(FederationVersion::LatestFedOne, false)]
+    #[case::fed1_unsupported(FederationVersion::ExactFedOne("0.37.2".parse().unwrap()), false)]
+    #[case::fed2_latest(FederationVersion::LatestFedTwo, true)]
+    #[case::fed2_supported(FederationVersion::ExactFedTwo("2.7.3".parse().unwrap()), true)]
+    #[case::fed2_supported_boundary(FederationVersion::ExactFedTwo("2.7.1".parse().unwrap()), true)]
+    #[case::fed2_unsupported(FederationVersion::ExactFedTwo("2.6.5".parse().unwrap()), false)]
+    fn test_supports_arm_macos(
+        #[case] version: FederationVersion,
+        #[case] expected: bool
+    ) {
+        assert_eq!(version.supports_arm_macos(), expected)
     }
 }

--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -122,14 +122,13 @@ impl FederationVersion {
 
     pub fn supports_arm_macos(&self) -> bool {
         let mut supports_arm = false;
+        // No published fed1 version supports aarch64 on macOS
         if self.is_fed_two() {
             if self.is_latest() {
                 supports_arm = true;
-            }
-            else {
-                if let Some(exact) = self.get_exact() {
+            } else if let Some(exact) = self.get_exact() {
+                    // v2.7.1 is the earliest version published with aarch64 support for macOS
                     supports_arm = exact.ge(&Version::parse("2.7.1").unwrap())
-                }
             }
         }
         supports_arm
@@ -307,10 +306,7 @@ mod test_federation_version {
     #[case::fed2_supported(FederationVersion::ExactFedTwo("2.4.5".parse().unwrap()), true)]
     #[case::fed2_supported_boundary(FederationVersion::ExactFedTwo("2.1.0".parse().unwrap()), true)]
     #[case::fed2_unsupported(FederationVersion::ExactFedTwo("2.0.1".parse().unwrap()), false)]
-    fn test_supports_arm_linux(
-        #[case] version: FederationVersion,
-        #[case] expected: bool
-    ) {
+    fn test_supports_arm_linux(#[case] version: FederationVersion, #[case] expected: bool) {
         assert_eq!(version.supports_arm_linux(), expected)
     }
 
@@ -321,10 +317,7 @@ mod test_federation_version {
     #[case::fed2_supported(FederationVersion::ExactFedTwo("2.7.3".parse().unwrap()), true)]
     #[case::fed2_supported_boundary(FederationVersion::ExactFedTwo("2.7.1".parse().unwrap()), true)]
     #[case::fed2_unsupported(FederationVersion::ExactFedTwo("2.6.5".parse().unwrap()), false)]
-    fn test_supports_arm_macos(
-        #[case] version: FederationVersion,
-        #[case] expected: bool
-    ) {
+    fn test_supports_arm_macos(#[case] version: FederationVersion, #[case] expected: bool) {
         assert_eq!(version.supports_arm_macos(), expected)
     }
 }

--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -119,6 +119,10 @@ impl FederationVersion {
         }
         supports_arm
     }
+
+    pub fn supports_arm_macos(&self) -> bool {
+        return false
+    }
 }
 
 impl PluginVersion for FederationVersion {
@@ -227,6 +231,7 @@ impl<'de> Deserialize<'de> for FederationVersion {
 
 #[cfg(test)]
 mod test_federation_version {
+    use rstest::rstest;
     use serde_yaml::Value;
 
     use crate::config::FederationVersion;
@@ -280,5 +285,21 @@ mod test_federation_version {
             FederationVersion::ExactFedOne("0.37.8".parse().unwrap()),
             serde_yaml::from_str("v0.37.8").unwrap()
         );
+    }
+
+    #[rstest]
+    #[case::fed1_latest(FederationVersion::LatestFedOne, true)]
+    #[case::fed1_supported(FederationVersion::ExactFedOne("0.37.2".parse().unwrap()), true)]
+    #[case::fed1_supported_boundary(FederationVersion::ExactFedOne("0.37.1".parse().unwrap()), true)]
+    #[case::fed1_unsupported(FederationVersion::ExactFedOne("0.25.0".parse().unwrap()), false)]
+    #[case::fed2_latest(FederationVersion::LatestFedTwo, true)]
+    #[case::fed2_supported(FederationVersion::ExactFedTwo("2.4.5".parse().unwrap()), true)]
+    #[case::fed2_supported_boundary(FederationVersion::ExactFedTwo("2.1.0".parse().unwrap()), true)]
+    #[case::fed2_unsupported(FederationVersion::ExactFedTwo("2.0.1".parse().unwrap()), false)]
+    fn test_supports_arm_linux(
+        #[case] version: FederationVersion,
+        #[case] expected: bool
+    ) {
+        assert_eq!(version.supports_arm_linux(), expected)
     }
 }


### PR DESCRIPTION
At present we have a check for ARM Linux support but no corresponding check for ARM on macOS. This adds that check and a test to ensure we retain the supported versions we want in the future.