### PR TITLE
release: apollo-federation-types@v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "assert_fs",
  "camino",

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.12.0"
+version = "0.13.0"
 
 [features]
 default = ["config", "build", "build_plugin"]

--- a/harmonizer/Cargo.toml
+++ b/harmonizer/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [dependencies]
-apollo-federation-types = { version = "0.12.0", path = "../apollo-federation-types", default-features = false, features = [
+apollo-federation-types = { version = "0.13.0", path = "../apollo-federation-types", default-features = false, features = [
   "build",
 ] }
 deno_core = "0.200.0"


### PR DESCRIPTION
Adding new function to `apollo-federation-types` to check ARM compatabilitity