### PR TITLE
Support the case where more than one action type could exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,7 @@ commands:
             while [ $attempt -lt $max_attempts ]; do
               RESULT=`curl -s -H "Authorization: token $GITHUB_TOKEN" \
                 -H "Accept: application/vnd.github.v3+json" \
-                "https://api.github.com/repos/apollographql/federation-rs/actions/runs?head_sha=$CIRCLE_SHA1" | jq -r '.workflow_runs[].conclusion'`
+                "https://api.github.com/repos/apollographql/federation-rs/actions/runs?head_sha=$CIRCLE_SHA1" | jq -r '.workflow_runs[] | {conclusion,name} | select(.name == "Mac_x86_tests").conclusion' | head -1` 
 
               echo "Attempt $((attempt+1)) of $max_attempts: RESULT is $RESULT"
 

--- a/.github/workflows/tests-mac-x86.yml
+++ b/.github/workflows/tests-mac-x86.yml
@@ -1,3 +1,5 @@
+name: Mac_x86_tests
+
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
For the release process, we will have Github actions for publish/release as well as the mac x86 test. Update the CircleCI script to be able to pick out the correct action