### PR TITLE
Move x86 Linux Compilation to `manylinux` container for continued `glibc` 2.17 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
           name: Lint
           matrix:
             parameters:
-              platform: [amd_centos]
+              platform: [amd_manylinux]
               rust_channel: [stable]
               command: [lint]
   test:
@@ -53,7 +53,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
+              platform: [amd_manylinux, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
               
@@ -71,7 +71,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
+              platform: [amd_manylinux, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -79,11 +79,11 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_centos, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_manylinux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
           requires:
-            - "Run cargo tests (stable rust on amd_centos)"
+            - "Run cargo tests (stable rust on amd_manylinux)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -105,7 +105,7 @@ workflows:
             parameters:
               platform: [minimal_linux]
           requires:
-            - "Build and bundle release artifacts (amd_centos)"
+            - "Build and bundle release artifacts (amd_manylinux)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_macos)"
             - "Build and bundle release artifacts (arm_macos)"
@@ -119,7 +119,7 @@ workflows:
             parameters:
               platform: [minimal_linux]
           requires:
-            - "Run cargo tests (stable rust on amd_centos)"
+            - "Run cargo tests (stable rust on amd_manylinux)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -235,9 +235,11 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-pc-windows-msvc"
 
-  amd_centos: &amd_centos_executor
+  amd_manylinux: &amd_manylinux_executor
     docker:
-      - image: centos:7
+      # This image is used for building Python Wheels but it has what we need for Rust compilation and crucially
+      # glibc 2.17.
+      - image: quay.io/pypa/manylinux2014_x86_64:2024.07.02-0
     resource_class: xlarge
     environment:
      XTASK_TARGET: "x86_64-unknown-linux-gnu"
@@ -273,7 +275,7 @@ commands:
     steps:
       - when:
           condition:
-            equal: [ *amd_centos_executor, << parameters.platform >> ]
+            equal: [ *amd_manylinux_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Update and upgrade yum packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
           name: Lint
           matrix:
             parameters:
-              platform: [amd_ubuntu]
+              platform: [amd_centos]
               rust_channel: [stable]
               command: [lint]
   test:
@@ -53,7 +53,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_ubuntu, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
               
@@ -71,7 +71,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_ubuntu, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -79,11 +79,11 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_ubuntu, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_centos, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
           requires:
-            - "Run cargo tests (stable rust on amd_ubuntu)"
+            - "Run cargo tests (stable rust on amd_centos)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -105,7 +105,7 @@ workflows:
             parameters:
               platform: [minimal_linux]
           requires:
-            - "Build and bundle release artifacts (amd_ubuntu)"
+            - "Build and bundle release artifacts (amd_centos)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_macos)"
             - "Build and bundle release artifacts (arm_macos)"
@@ -119,7 +119,7 @@ workflows:
             parameters:
               platform: [minimal_linux]
           requires:
-            - "Run cargo tests (stable rust on amd_ubuntu)"
+            - "Run cargo tests (stable rust on amd_centos)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -235,6 +235,12 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-pc-windows-msvc"
 
+  amd_centos: &amd_centos_executor
+    docker:
+      - image: centos:7
+    resource_class: xlarge
+    environment:
+     XTASK_TARGET: "x86_64-unknown-linux-gnu"
   amd_linux: &amd_linux_build_executor
     docker:
       - image: cimg/base:stable
@@ -247,14 +253,6 @@ executors:
     resource_class: arm.large
     environment:
       XTASK_TARGET: "aarch64-unknown-linux-gnu"
-
-  amd_ubuntu: &amd_ubuntu_executor
-    machine:
-      image: ubuntu-2004:2022.04.1
-    resource_class: xlarge
-    environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
-      CAN_RUN_DOCKER: "true"
 
   minimal_linux:
     docker:
@@ -275,14 +273,26 @@ commands:
     steps:
       - when:
           condition:
-            equal: [ *amd_ubuntu_executor, << parameters.platform >> ]
+            equal: [ *amd_centos_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Update and upgrade yum packages
-                command: sudo apt update
+                command: yum -y update && yum -y upgrade
             - run:
                 name: Install development tools
-                command: sudo apt install build-essential
+                command: yum groupinstall -y "Development Tools"
+            - run:
+                name: Install gcc
+                command: yum -y install perl-core gcc
+            - run:
+                name: Install CMake
+                command: |
+                  cd /usr/local/src
+                  curl -LO https://github.com/Kitware/CMake/releases/download/v<< pipeline.parameters.linux_cmake_version >>/cmake-<< pipeline.parameters.linux_cmake_version >>-linux-x86_64.tar.gz
+                  tar -xvf cmake-<< pipeline.parameters.linux_cmake_version >>-linux-x86_64.tar.gz
+                  mv cmake-<< pipeline.parameters.linux_cmake_version >>-linux-x86_64 /usr/local/cmake
+                  echo 'export PATH="/usr/local/cmake/bin:$PATH"' >> $BASH_ENV
+                  source $BASH_ENV
             - run:
                 name: Check glibc version
                 command: ldd --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
           name: Lint
           matrix:
             parameters:
-              platform: [amd_manylinux]
+              platform: [amd_linux]
               rust_channel: [stable]
               command: [lint]
   test:
@@ -53,7 +53,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_manylinux, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
               
@@ -71,7 +71,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_manylinux, arm_ubuntu, amd_linux, amd_macos, arm_macos, amd_windows]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -79,11 +79,11 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_manylinux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
               rust_channel: [stable]
               command: [package]
           requires:
-            - "Run cargo tests (stable rust on amd_manylinux)"
+            - "Run cargo tests (stable rust on amd_linux)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -105,7 +105,7 @@ workflows:
             parameters:
               platform: [minimal_linux]
           requires:
-            - "Build and bundle release artifacts (amd_manylinux)"
+            - "Build and bundle release artifacts (amd_linux)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_macos)"
             - "Build and bundle release artifacts (arm_macos)"
@@ -119,7 +119,7 @@ workflows:
             parameters:
               platform: [minimal_linux]
           requires:
-            - "Run cargo tests (stable rust on amd_manylinux)"
+            - "Run cargo tests (stable rust on amd_linux)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -235,7 +235,7 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-pc-windows-msvc"
 
-  amd_manylinux: &amd_manylinux_executor
+  amd_linux: &amd_linux_executor
     docker:
       # This image is used for building Python Wheels but it has what we need for Rust compilation and crucially
       # glibc 2.17.
@@ -243,12 +243,6 @@ executors:
     resource_class: xlarge
     environment:
      XTASK_TARGET: "x86_64-unknown-linux-gnu"
-  amd_linux: &amd_linux_build_executor
-    docker:
-      - image: cimg/base:stable
-    resource_class: xlarge
-    environment:
-      XTASK_TARGET: "x86_64-unknown-linux-gnu"
   arm_ubuntu: &arm_ubuntu_executor
     machine:
       image: ubuntu-2004:2022.04.1
@@ -275,7 +269,7 @@ commands:
     steps:
       - when:
           condition:
-            equal: [ *amd_manylinux_executor, << parameters.platform >> ]
+            equal: [ *amd_linux_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Update and upgrade yum packages


### PR DESCRIPTION
As per title, copying an approach we used for Rover after the CentOS EOL.