### PR TITLE
Send payload id if applicable when an exception is caught

### DIFF
--- a/router-bridge/js-src/plan_worker.ts
+++ b/router-bridge/js-src/plan_worker.ts
@@ -245,8 +245,14 @@ const updateQueryPlanner = (
 
 async function run() {
   while (true) {
+    // If an Exception is raised,
+    // there won't be any messageId to send a payload back to the router,
+    // unless we keep it in this scope.
+    let messageId;
     try {
+      messageId = "";
       const { id, payload: event } = await receive();
+      messageId = id;
       try {
         switch (event?.kind) {
           case PlannerEventKind.UpdateSchema:
@@ -336,6 +342,7 @@ async function run() {
       };
 
       await send({
+        id: messageId,
         payload: {
           errors: [unexpectedError],
           usageReporting: {

--- a/router-bridge/js-src/plan_worker.ts
+++ b/router-bridge/js-src/plan_worker.ts
@@ -248,9 +248,8 @@ async function run() {
     // If an Exception is raised,
     // there won't be any messageId to send a payload back to the router,
     // unless we keep it in this scope.
-    let messageId;
+    let messageId = "";
     try {
-      messageId = "";
       const { id, payload: event } = await receive();
       messageId = id;
       try {


### PR DESCRIPTION
If an exception is caught during planning, we previously didn't send the messageId.

The response could thus not be properly routed back to the proper sender, and would lead to such errors as:

```
value: TypeError: Error parsing args at position 1: missing field `id`
```

This changeset adds the messageId if possible.