### PR TITLE
impl `From<BuildError>` and `From<BuildHint>` for `Issue`

### DIFF
--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -378,8 +378,8 @@ fn satisfiability_result_into_issues(
 impl From<BuildError> for Issue {
     fn from(error: BuildError) -> Issue {
         Issue {
-            code: error.code.unwrap_or("UNKNOWN_ERROR_CODE".to_string()),
-            message: error.message.unwrap_or("Unknown error".to_string()),
+            code: error.code.unwrap_or_else(|| "UNKNOWN_ERROR_CODE".to_string()),
+            message: error.message.unwrap_or_else(|| "Unknown error".to_string()),
             locations: error
                 .nodes
                 .unwrap_or_default()
@@ -394,7 +394,7 @@ impl From<BuildError> for Issue {
 impl From<BuildHint> for Issue {
     fn from(hint: BuildHint) -> Issue {
         Issue {
-            code: hint.code.unwrap_or("UNKNOWN_HINT_CODE".to_string()),
+            code: hint.code.unwrap_or_else(|| "UNKNOWN_HINT_CODE".to_string()),
             message: hint.message,
             locations: hint
                 .nodes

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -396,14 +396,15 @@ impl From<BuildMessageLocation> for SubgraphLocation {
         Self {
             subgraph: location.subgraph.unwrap_or_default(),
             range: location.start.and_then(|start| {
-                location.end.map(|end| Range {
+                let end = location.end?;
+                Some(Range {
                     start: LineColumn {
-                        line: start.line.unwrap_or_default(),
-                        column: start.column.unwrap_or_default(),
+                        line: start.line?,
+                        column: start.column?,
                     },
                     end: LineColumn {
-                        line: end.line.unwrap_or_default(),
-                        column: end.column.unwrap_or_default(),
+                        line: end.line?,
+                        column: end.column?,
                     },
                 })
             }),

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -378,7 +378,9 @@ fn satisfiability_result_into_issues(
 impl From<BuildError> for Issue {
     fn from(error: BuildError) -> Issue {
         Issue {
-            code: error.code.unwrap_or_else(|| "UNKNOWN_ERROR_CODE".to_string()),
+            code: error
+                .code
+                .unwrap_or_else(|| "UNKNOWN_ERROR_CODE".to_string()),
             message: error.message.unwrap_or_else(|| "Unknown error".to_string()),
             locations: error
                 .nodes

--- a/apollo-federation-types/src/build_plugin/build_message.rs
+++ b/apollo-federation-types/src/build_plugin/build_message.rs
@@ -26,7 +26,7 @@ pub struct BuildMessageLocation {
     pub other: crate::UncaughtJson,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct BuildMessagePoint {
     pub start: Option<usize>,
     pub end: Option<usize>,

--- a/apollo-federation-types/src/build_plugin/build_message.rs
+++ b/apollo-federation-types/src/build_plugin/build_message.rs
@@ -26,7 +26,7 @@ pub struct BuildMessageLocation {
     pub other: crate::UncaughtJson,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BuildMessagePoint {
     pub start: Option<usize>,
     pub end: Option<usize>,


### PR DESCRIPTION
LSP in Rover needs composition issues in the form of `Issue`s. These implementations allow for easy translation from `supergraph` output into what the language server expects.