### PR TITLE
get heap statistics from deno

### DIFF
--- a/router-bridge/js-src/plan_worker.ts
+++ b/router-bridge/js-src/plan_worker.ts
@@ -24,6 +24,19 @@ declare let logger: {
   error: typeof logFunction;
 };
 
+export interface MemoryUsage {
+  /** The number of bytes of the current Deno's process resident set size,
+   * which is the amount of memory occupied in main memory (RAM). */
+  rss: number;
+  /** The total size of the heap for V8, in bytes. */
+  heapTotal: number;
+  /** The amount of the heap used for V8, in bytes. */
+  heapUsed: number;
+  /** Memory, in bytes, associated with JavaScript objects outside of the
+   * JavaScript isolate. */
+  external: number;
+}
+
 enum PlannerEventKind {
   UpdateSchema = "UpdateSchema",
   Plan = "Plan",
@@ -32,6 +45,7 @@ enum PlannerEventKind {
   Introspect = "Introspect",
   Signature = "Signature",
   Subgraphs = "Subgraphs",
+  GetHeapStatistics = "GetHeapStatistics",
 }
 
 interface UpdateSchemaEvent {
@@ -75,6 +89,11 @@ interface Exit {
   kind: PlannerEventKind.Exit;
   schemaId: number;
 }
+
+interface GetHeapStatisticsEvent {
+  kind: PlannerEventKind.GetHeapStatistics;
+}
+
 type PlannerEvent =
   | UpdateSchemaEvent
   | PlanEvent
@@ -82,6 +101,7 @@ type PlannerEvent =
   | IntrospectEvent
   | SignatureEvent
   | SubgraphsEvent
+  | GetHeapStatisticsEvent
   | Exit;
 type PlannerEventWithId = {
   id: string;
@@ -92,18 +112,26 @@ type WorkerResultWithId = {
   id?: string;
   payload: WorkerResult;
 };
+
 type WorkerResult =
   | PlanResult
   | ApiSchemaResult
   | ExecutionResult
   | Map<string, string>
-  | String;
+  | String
+  | MemoryUsageResult;
 // Plan result
 type PlanResult =
   | ExecutionResultWithUsageReporting<QueryPlanResult>
   | FatalError;
 type ApiSchemaResult = {
   schema: string;
+};
+type MemoryUsageResult = {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
 };
 
 type FatalError = {
@@ -289,6 +317,29 @@ async function run() {
             const subgraphs = planners.get(event.schemaId).subgraphs();
 
             await send({ id, payload: subgraphs });
+            break;
+          case PlannerEventKind.GetHeapStatistics:
+            logger.info(`received event: ${JSON.stringify(event)}`);
+
+            const mem = Deno.memoryUsage();
+            //const mem = memoryUsage();
+
+            logger.info(`got memoryUsage`);
+            const result: MemoryUsageResult = {
+              rss: mem.rss,
+              heapTotal: mem.heapTotal,
+              heapUsed: mem.heapUsed,
+              external: mem.external,
+            };
+            /*const result: MemoryUsageResult = {
+              rss: 1,
+              heapTotal: 2,
+              heapUsed: 3,
+              external: 4,
+            };*/
+            logger.info(`memoryUsage: ${JSON.stringify(result)}`);
+
+            await send({ id, payload: result });
             break;
           case PlannerEventKind.Exit:
             planners.delete(event.schemaId);

--- a/router-bridge/js-src/plan_worker.ts
+++ b/router-bridge/js-src/plan_worker.ts
@@ -29,9 +29,6 @@ declare let logger: {
 };
 
 export interface MemoryUsage {
-  /* The number of bytes of the current Deno's process resident set size,
-   * which is the amount of memory occupied in main memory (RAM). */
-  //rss: number;
   /** The total size of the heap for V8, in bytes. */
   heapTotal: number;
   /** The amount of the heap used for V8, in bytes. */
@@ -132,7 +129,6 @@ type ApiSchemaResult = {
   schema: string;
 };
 type MemoryUsageResult = {
-  //rss: number;
   heapTotal: number;
   heapUsed: number;
   external: number;
@@ -324,25 +320,13 @@ async function run() {
             await send({ id, payload: subgraphs });
             break;
           case PlannerEventKind.GetHeapStatistics:
-            logger.info(`received event: ${JSON.stringify(event)}`);
-
-            //const mem = Deno.memoryUsage();
             const mem = memoryUsage();
 
-            logger.info(`got memoryUsage`);
             const result: MemoryUsageResult = {
-              //rss: mem.rss,
               heapTotal: mem.heapTotal,
               heapUsed: mem.heapUsed,
               external: mem.external,
             };
-            /*const result: MemoryUsageResult = {
-              rss: 1,
-              heapTotal: 2,
-              heapUsed: 3,
-              external: 4,
-            };*/
-            logger.info(`memoryUsage: ${JSON.stringify(result)}`);
 
             await send({ id, payload: result });
             break;

--- a/router-bridge/js-src/plan_worker.ts
+++ b/router-bridge/js-src/plan_worker.ts
@@ -15,6 +15,10 @@ declare namespace Deno {
   }
 }
 
+function memoryUsage(): MemoryUsage {
+  return Deno.core.ops.op_runtime_memory_usage();
+}
+
 let logFunction: (message: string) => void;
 declare let logger: {
   trace: typeof logFunction;
@@ -25,9 +29,9 @@ declare let logger: {
 };
 
 export interface MemoryUsage {
-  /** The number of bytes of the current Deno's process resident set size,
+  /* The number of bytes of the current Deno's process resident set size,
    * which is the amount of memory occupied in main memory (RAM). */
-  rss: number;
+  //rss: number;
   /** The total size of the heap for V8, in bytes. */
   heapTotal: number;
   /** The amount of the heap used for V8, in bytes. */
@@ -128,7 +132,7 @@ type ApiSchemaResult = {
   schema: string;
 };
 type MemoryUsageResult = {
-  rss: number;
+  //rss: number;
   heapTotal: number;
   heapUsed: number;
   external: number;
@@ -280,6 +284,7 @@ async function run() {
     try {
       const { id, payload: event } = await receive();
       messageId = id;
+
       try {
         switch (event?.kind) {
           case PlannerEventKind.UpdateSchema:
@@ -321,12 +326,12 @@ async function run() {
           case PlannerEventKind.GetHeapStatistics:
             logger.info(`received event: ${JSON.stringify(event)}`);
 
-            const mem = Deno.memoryUsage();
-            //const mem = memoryUsage();
+            //const mem = Deno.memoryUsage();
+            const mem = memoryUsage();
 
             logger.info(`got memoryUsage`);
             const result: MemoryUsageResult = {
-              rss: mem.rss,
+              //rss: mem.rss,
               heapTotal: mem.heapTotal,
               heapUsed: mem.heapUsed,
               external: mem.external,

--- a/router-bridge/src/planner.rs
+++ b/router-bridge/src/planner.rs
@@ -400,10 +400,13 @@ where
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+/// deno's heap statistics
 pub struct HeapStatistics {
-    //pub rss: u64,
+    /// total size of the heap for V8, in bytes
     pub heap_total: u64,
+    /// amount of the heap used for V8, in bytes
     pub heap_used: u64,
+    /// emory, in bytes, associated with JavaScript objects outside of the JavaScript isolate
     pub external: u64,
 }
 

--- a/router-bridge/src/planner.rs
+++ b/router-bridge/src/planner.rs
@@ -787,10 +787,9 @@ pub struct QueryPlannerDebugConfig {
 }
 #[cfg(test)]
 mod tests {
+    use futures::stream;
     use futures::stream::StreamExt;
-    use futures::stream::{self};
 
-    use core::panic;
     use std::collections::BTreeMap;
 
     use super::*;
@@ -1904,7 +1903,6 @@ ofType {
         let statistics = planner.get_heap_statistics().await.unwrap();
 
         println!("statistics: {statistics:?}");
-        panic!()
     }
 }
 

--- a/router-bridge/src/planner.rs
+++ b/router-bridge/src/planner.rs
@@ -401,7 +401,7 @@ where
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct HeapStatistics {
-    pub rss: u64,
+    //pub rss: u64,
     pub heap_total: u64,
     pub heap_used: u64,
     pub external: u64,
@@ -787,6 +787,7 @@ mod tests {
     use futures::stream::StreamExt;
     use futures::stream::{self};
 
+    use core::panic;
     use std::collections::BTreeMap;
 
     use super::*;

--- a/router-bridge/src/worker.rs
+++ b/router-bridge/src/worker.rs
@@ -313,6 +313,8 @@ struct MemoryUsage {
     external: usize,
 }
 
+// from https://github.com/denoland/deno/blob/897159dc6e1b2319cf2f5f09d8d6cecc0d3175fa/runtime/ops/os/mod.rs#L329
+// tested in planner.rs
 #[op(v8)]
 fn op_runtime_memory_usage(scope: &mut v8::HandleScope<'_>) -> MemoryUsage {
     let mut s = v8::HeapStatistics::default();


### PR DESCRIPTION
This adds a planner event to request V8 heap statistics.

This data is gathered from the JS side because the related methods from the rust side require a `&mut` access to the runtime, which is impossible since it already runs in an infinite loop.
Since we elected to not run the prelude parts of deno which register functions like `Deno.memory_usage`, we intern the [op_runtime_memory_usage function](https://github.com/denoland/deno/blob/897159dc6e1b2319cf2f5f09d8d6cecc0d3175fa/runtime/ops/os/mod.rs#L329) and import it directly as a host function, as we've done already with  `op_crypto_get_random_values`. To avoid hosting too much code, the `rss` field is not filled (it needs platform specific functions), since that info can generally be obtained by other means.