### PR TITLE
Build MUSL binaries as well as `glibc` ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-musl"
       V8_FROM_SOURCE: "1"
-      GN_ARGS: "is_clang=false custom_toolchain=\"x86_64-linux-musl-gcc\""
+      CLANG_BASE_PATH: "/usr/bin"
 
 
 # reusable command snippets can be referred to in any `steps` object
@@ -326,7 +326,7 @@ commands:
           steps:
             - run:
                 name: Install Alpine required Dependencies
-                command: apk add curl bash nodejs npm cmake g++ make python3 gn git gcc glib-dev icu-dev libstdc++ linux-headers ninja tar xz
+                command: apk add curl bash nodejs npm cmake g++ make python3 gn git gcc glib-dev icu-dev libstdc++ linux-headers ninja tar xz musl-dev
 
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ commands:
           steps:
             - run:
                 name: Install musl-tools and bash
-                command: sudo apt-get install -y musl-tools bash
+                command: sudo apt-get install -y musl-tools bash musl-dev
 
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,10 +262,12 @@ executors:
 
   amd_musl: &amd_musl_executor
     docker:
-      - image: cimg/base:stable
+      - image: rust:alpine3.19
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-musl"
+      V8_FROM_SOURCE: "true"
+
 
 # reusable command snippets can be referred to in any `steps` object
 commands:
@@ -322,8 +324,8 @@ commands:
             equal: [*amd_musl_executor, << parameters.platform >>]
           steps:
             - run:
-                name: Install musl-tools and bash
-                command: sudo apt-get install -y musl-tools bash musl-dev
+                name: Install Alpine required Dependencies
+                command: apk add musl-dev curl bash nodejs npm cmake g++ make python3 gn clang build-base llvm-static llvm-dev clang-static clang-dev git
 
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
@@ -341,6 +343,7 @@ commands:
             or:
               - equal: [ *amd_windows_executor, << parameters.platform >> ]
               - equal: [ *arm_ubuntu_executor, << parameters.platform >> ]
+              - equal: [ *amd_musl_executor, << parameters.platform >> ]
           steps:
             - run:
                 name: Install volta
@@ -348,7 +351,6 @@ commands:
                   curl https://get.volta.sh | bash -s -- --skip-setup
                   echo 'export VOLTA_HOME=$HOME/.volta' >> $BASH_ENV
                   echo 'export PATH=$VOLTA_HOME/bin:$PATH' >> $BASH_ENV
-
       - when:
           condition:
             equal: [ *arm_ubuntu_executor, << parameters.platform >> ]
@@ -390,11 +392,15 @@ commands:
                   choco install cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=User'
                   exit $LASTEXITCODE
 
-      - run:
-          name: Install default versions of npm and node
-          command: |
-            volta install node@16
-            volta install npm@8
+      - unless:
+          condition:
+            equal: [ *amd_musl_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Install default versions of npm and node
+                command: |
+                  volta install node@16
+                  volta install npm@8
 
 
   install_rust_toolchain:
@@ -407,10 +413,16 @@ commands:
     steps:
       - unless:
           condition:
-            equal: [ *amd_windows_executor, << parameters.platform >> ]
+            or:
+              - equal: [ *amd_windows_executor, << parameters.platform >> ]
+              - equal: [ *amd_musl_executor, << parameters.platform >> ]
           steps:
             - rust/install:
                 version: << parameters.rust_channel >>
+      - unless:
+          condition:
+            equal: [ *amd_windows_executor, << parameters.platform >> ]
+          steps:
             - run:
                 name: Adds rust target
                 command: rustup target add $XTASK_TARGET

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,8 +267,10 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-musl"
       V8_FROM_SOURCE: "1"
-      CLANG_BASE_PATH: "/usr/bin"
-
+      CLANG_BASE_PATH: "/usr"
+      GN_ARGS: "use_custom_libcxx=false use_lld=false v8_enable_backtrace=false v8_enable_debugging_features=false"
+      GN: "/usr/bin/gn"
+      PYTHON: "python3"
 
 # reusable command snippets can be referred to in any `steps` object
 commands:
@@ -326,7 +328,7 @@ commands:
           steps:
             - run:
                 name: Install Alpine required Dependencies
-                command: apk add curl bash nodejs npm cmake g++ make python3 gn git gcc glib-dev icu-dev libstdc++ linux-headers ninja tar xz musl-dev
+                command: apk add curl bash nodejs npm git gcc ninja python3 clang g++ pkgconfig glib-dev llvm17-dev binutils-gold gn make cmake zlib zlib-ng
 
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
@@ -485,6 +487,7 @@ commands:
       #       - &target-cache-key rust-target-v3-<< parameters.platform >>-{{ .Branch }}-{{ checksum "Cargo.lock" }}
 
       - run:
+          no_output_timeout: 30m
           command: cargo xtask << parameters.command >> << parameters.options >>
           working_directory: << parameters.working_directory >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, musl_linux]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, amd_musl]
               rust_channel: [stable]
               command: [test]
               
@@ -71,7 +71,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, musl_linux]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, amd_musl]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -79,12 +79,12 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, musl_linux]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, amd_musl]
               rust_channel: [stable]
               command: [package]
           requires:
             - "Run cargo tests (stable rust on amd_linux)"
-            - "Run cargo tests (stable rust on musl_linux)"
+            - "Run cargo tests (stable rust on amd_musl)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -107,7 +107,7 @@ workflows:
               platform: [minimal_linux]
           requires:
             - "Build and bundle release artifacts (amd_linux)"
-            - "Build and bundle release artifacts (musl_linux)"
+            - "Build and bundle release artifacts (amd_musl)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_macos)"
             - "Build and bundle release artifacts (arm_macos)"
@@ -122,7 +122,7 @@ workflows:
               platform: [minimal_linux]
           requires:
             - "Run cargo tests (stable rust on amd_linux)"
-            - "Run cargo tests (stable rust on musl_linux)"
+            - "Run cargo tests (stable rust on amd_musl)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, musl_linux]
               rust_channel: [stable]
               command: [test]
               
@@ -71,7 +71,7 @@ workflows:
           name: Run cargo tests (<< matrix.rust_channel >> rust on << matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, musl_linux]
               rust_channel: [stable]
               command: [test]
           <<: *any_release
@@ -79,11 +79,12 @@ workflows:
           name: Build and bundle release artifacts (<< matrix.platform >>)
           matrix:
             parameters:
-              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows]
+              platform: [amd_linux, arm_ubuntu, amd_macos, arm_macos, amd_windows, musl_linux]
               rust_channel: [stable]
               command: [package]
           requires:
             - "Run cargo tests (stable rust on amd_linux)"
+            - "Run cargo tests (stable rust on musl_linux)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -106,6 +107,7 @@ workflows:
               platform: [minimal_linux]
           requires:
             - "Build and bundle release artifacts (amd_linux)"
+            - "Build and bundle release artifacts (musl_linux)"
             - "Build and bundle release artifacts (arm_ubuntu)"
             - "Build and bundle release artifacts (amd_macos)"
             - "Build and bundle release artifacts (arm_macos)"
@@ -120,6 +122,7 @@ workflows:
               platform: [minimal_linux]
           requires:
             - "Run cargo tests (stable rust on amd_linux)"
+            - "Run cargo tests (stable rust on musl_linux)"
             - "Run cargo tests (stable rust on arm_ubuntu)"
             - "Run cargo tests (stable rust on amd_macos)"
             - "Run cargo tests (stable rust on arm_macos)"
@@ -257,6 +260,13 @@ executors:
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-gnu"
 
+  amd_musl: &amd_musl_executor
+    docker:
+      - image: cimg/base:stable
+    resource_class: xlarge
+    environment:
+      XTASK_TARGET: "x86_64-unknown-linux-musl"
+
 # reusable command snippets can be referred to in any `steps` object
 commands:
   install_system_deps:
@@ -307,13 +317,20 @@ commands:
                 command: |
                   brew install cmake
 
+      - when:
+          condition:
+            equal: [*amd_musl_executor, << parameters.platform >>]
+          steps:
+            - run:
+                name: Install musl-tools and bash
+                command: sudo apt-get install -y musl-tools bash
+
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>
           platform: << parameters.platform >>
 
       - install_volta:
           platform: << parameters.platform >>
-
   install_volta:
     parameters:
       platform:
@@ -471,7 +488,6 @@ commands:
                 root: artifacts
                 paths:
                   - "*"
-
   compute_checksums:
     steps:
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,8 @@ executors:
     resource_class: xlarge
     environment:
       XTASK_TARGET: "x86_64-unknown-linux-musl"
-      V8_FROM_SOURCE: "true"
+      V8_FROM_SOURCE: "1"
+      GN_ARGS: "is_clang=false custom_toolchain=\"x86_64-linux-musl-gcc\""
 
 
 # reusable command snippets can be referred to in any `steps` object
@@ -325,7 +326,7 @@ commands:
           steps:
             - run:
                 name: Install Alpine required Dependencies
-                command: apk add musl-dev curl bash nodejs npm cmake g++ make python3 gn clang build-base llvm-static llvm-dev clang-static clang-dev git
+                command: apk add curl bash nodejs npm cmake g++ make python3 gn git gcc glib-dev icu-dev libstdc++ linux-headers ninja tar xz
 
       - install_rust_toolchain:
           rust_channel: << parameters.rust_channel >>

--- a/harmonizer/build.rs
+++ b/harmonizer/build.rs
@@ -14,10 +14,6 @@ fn main() {
     let out_dir = std::env::var_os("OUT_DIR").expect("$OUT_DIR not set.");
     println!("cargo:rerun-if-changed={:?}", &out_dir);
     let out_dir: PathBuf = out_dir.into();
-    if cfg!(target_arch = "musl") {
-        panic!("This package cannot be built for musl architectures.");
-    }
-
     let current_dir = std::env::current_dir().unwrap();
 
     // only do `npm` related stuff if we're _not_ publishing to crates.io

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fmt, str::FromStr};
 use crate::Result;
 
 pub(crate) const TARGET_LINUX_UNKNOWN_GNU: &str = "x86_64-unknown-linux-gnu";
+pub(crate) const TARGET_LINUX_UNKNOWN_MUSL: &str = "x86_64-unknown-linux-musl";
 pub(crate) const TARGET_LINUX_ARM: &str = "aarch64-unknown-linux-gnu";
 pub(crate) const TARGET_WINDOWS_MSVC: &str = "x86_64-pc-windows-msvc";
 pub(crate) const TARGET_MACOS_INTEL: &str = "x86_64-apple-darwin";
@@ -14,11 +15,13 @@ pub(crate) const POSSIBLE_TARGETS: [&str; 5] = [
     TARGET_WINDOWS_MSVC,
     TARGET_MACOS_INTEL,
     TARGET_MACOS_ARM,
+    TARGET_LINUX_UNKNOWN_MUSL,
 ];
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) enum Target {
     LinuxUnknownGnu,
+    LinuxUnknownMusl,
     LinuxAarch,
     WindowsMsvc,
     MacOSIntel,
@@ -47,7 +50,12 @@ impl Target {
 
     #[allow(unused)]
     pub(crate) fn is_linux(&self) -> bool {
-        Self::LinuxAarch == *self || Self::LinuxUnknownGnu == *self
+        Self::LinuxAarch == *self || Self::LinuxUnknownGnu == *self || Self::LinuxUnknownMusl == *self
+    }
+
+    #[allow(unused)]
+    pub(crate) fn is_musl(&self) -> bool {
+        Self::LinuxUnknownMusl == *self
     }
 
     pub(crate) fn is_windows(&self) -> bool {
@@ -61,6 +69,11 @@ impl Target {
                 "RUSTFLAGS".to_string(),
                 "-Ctarget-feature=+crt-static".to_string(),
             );
+        }
+        if self.is_musl() {
+            env.insert(
+                "V8_FROM_SOURCE".to_string(), true.to_string()
+            )
         }
         Ok(env)
     }

--- a/xtask/src/target.rs
+++ b/xtask/src/target.rs
@@ -9,7 +9,7 @@ pub(crate) const TARGET_WINDOWS_MSVC: &str = "x86_64-pc-windows-msvc";
 pub(crate) const TARGET_MACOS_INTEL: &str = "x86_64-apple-darwin";
 pub(crate) const TARGET_MACOS_ARM: &str = "aarch64-apple-darwin";
 
-pub(crate) const POSSIBLE_TARGETS: [&str; 5] = [
+pub(crate) const POSSIBLE_TARGETS: [&str; 6] = [
     TARGET_LINUX_UNKNOWN_GNU,
     TARGET_LINUX_ARM,
     TARGET_WINDOWS_MSVC,
@@ -73,7 +73,7 @@ impl Target {
         if self.is_musl() {
             env.insert(
                 "V8_FROM_SOURCE".to_string(), true.to_string()
-            )
+            );
         }
         Ok(env)
     }
@@ -128,6 +128,7 @@ impl fmt::Display for Target {
             Target::WindowsMsvc => TARGET_WINDOWS_MSVC,
             Target::MacOSIntel => TARGET_MACOS_INTEL,
             Target::MacOSArm => TARGET_MACOS_ARM,
+            Target::LinuxUnknownMusl => TARGET_LINUX_UNKNOWN_MUSL,
             Target::Other => "unknown-target",
         };
         write!(f, "{msg}")


### PR DESCRIPTION
Seems as though we can build `musl` binaries if we want too, though it requires compiling V8 at source, this PR is an experiment to see if that's possible.

In terms of testing I've done the following:
1. Spun up a `cimg/base:stable` Docker image, installed the right tools and built the binary using the same xtask command as is used in CI - ✅ 
2. Installed `rover` in the same Docker image, moved the built `supergraph` binary into the `.rover/bin` directory and run `supergraph compose` against the `retail-supergraph` example - ✅ 
3. Re-done 1. without the `--debug` flag to ensure that we can get a release binary ✅ 

I'm happy to do anymore testing we think is a good idea, because supporting a new binary is a big deal so I want to make sure we're ready if we decide to go ahead.