### PR TITLE
Fix serialization structs for composition results

### DIFF
--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -286,16 +286,17 @@ impl From<SubgraphLocation> for BuildMessageLocation {
 
 impl SubgraphLocation {
     fn from_ast(node: SubgraphASTNode) -> Option<Self> {
+        let loc = node.loc?;
         Some(Self {
             subgraph: node.subgraph.unwrap_or_default(),
             range: Some(Range {
                 start: LineColumn {
-                    line: node.loc.start_token.line?,
-                    column: node.loc.start_token.column?,
+                    line: loc.start_token.line?,
+                    column: loc.start_token.column?,
                 },
                 end: LineColumn {
-                    line: node.loc.end_token.line?,
-                    column: node.loc.end_token.column?,
+                    line: loc.end_token.line?,
+                    column: loc.end_token.column?,
                 },
             }),
         })
@@ -328,6 +329,7 @@ impl From<CompositionHint> for Issue {
             severity: Severity::Warning,
             locations: hint
                 .nodes
+                .unwrap_or_default()
                 .into_iter()
                 .filter_map(SubgraphLocation::from_ast)
                 .collect(),

--- a/apollo-federation-types/src/javascript/mod.rs
+++ b/apollo-federation-types/src/javascript/mod.rs
@@ -30,8 +30,7 @@ pub struct SatisfiabilityResult {
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CompositionHint {
     pub message: String,
-    #[serde(default)]
-    pub nodes: Vec<SubgraphASTNode>,
+    pub nodes: Option<Vec<SubgraphASTNode>>,
     pub definition: HintCodeDefinition,
 }
 
@@ -42,7 +41,7 @@ pub struct HintCodeDefinition {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SubgraphASTNode {
-    pub loc: Location,
+    pub loc: Option<Location>,
     pub subgraph: Option<String>,
 }
 


### PR DESCRIPTION
While testing Apollo's graph in the browser, I came across a couple other cases that are problematic when serializing composition results, so I've updated the types to match reality.

* `loc` can be undefined
* `#[serde(default)]` only works if the key does not exist. Composition defines the key and sets it to `undefined`, so `nodes` should be an actual `Option` to represent that.
