### PR TITLE
🐛 fix subgraph location from ast

### DIFF
--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -287,18 +287,19 @@ impl From<SubgraphLocation> for BuildMessageLocation {
 
 impl SubgraphLocation {
     fn from_ast(node: SubgraphASTNode) -> Option<Self> {
-        let loc = node.loc?;
         Some(Self {
-            subgraph: node.subgraph.unwrap_or_default(),
-            range: Some(Range {
-                start: LineColumn {
-                    line: loc.start_token.line?,
-                    column: loc.start_token.column?,
-                },
-                end: LineColumn {
-                    line: loc.end_token.line?,
-                    column: loc.end_token.column?,
-                },
+            subgraph: node.subgraph?,
+            range: node.loc.and_then(|node_loc| {
+                Some(Range {
+                    start: LineColumn {
+                        line: node_loc.start_token.line?,
+                        column: node_loc.start_token.column?,
+                    },
+                    end: LineColumn {
+                        line: node_loc.end_token.line?,
+                        column: node_loc.end_token.column?,
+                    },
+                })
             }),
         })
     }


### PR DESCRIPTION
We were returning `None` if there was no location, even if we had a subgraph. If there is a subgraph, but no location we still want to return `Some` and just have a `None` range, this way the error can still be mapped to the subgraph instead of being treated as a global. 