### PR TITLE
Add new FromIterator method

### DIFF
--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -165,7 +165,7 @@ impl IntoIterator for SupergraphConfig {
 }
 
 impl FromIterator<(String, SubgraphConfig)> for SupergraphConfig {
-    fn from_iter<T: IntoIterator<Item=(String, SubgraphConfig)>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = (String, SubgraphConfig)>>(iter: T) -> Self {
         let mut subgraphs = BTreeMap::new();
         for (name, subgraph_config) in iter {
             subgraphs.insert(name, subgraph_config);

--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -1,10 +1,12 @@
-use crate::config::{ConfigError, ConfigResult, FederationVersion, SubgraphConfig};
+use std::{collections::BTreeMap, fs};
 
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 
-use crate::javascript::SubgraphDefinition;
-use std::{collections::BTreeMap, fs};
+use crate::{
+    config::{ConfigError, ConfigResult, FederationVersion, SubgraphConfig},
+    javascript::SubgraphDefinition,
+};
 
 /// The configuration for a single supergraph
 /// composed of multiple subgraphs.
@@ -166,12 +168,8 @@ impl IntoIterator for SupergraphConfig {
 
 impl FromIterator<(String, SubgraphConfig)> for SupergraphConfig {
     fn from_iter<T: IntoIterator<Item = (String, SubgraphConfig)>>(iter: T) -> Self {
-        let mut subgraphs = BTreeMap::new();
-        for (name, subgraph_config) in iter {
-            subgraphs.insert(name, subgraph_config);
-        }
         Self {
-            subgraphs,
+            subgraphs: iter.into_iter().collect::<BTreeMap<_, _>>(),
             federation_version: None,
         }
     }
@@ -179,16 +177,15 @@ impl FromIterator<(String, SubgraphConfig)> for SupergraphConfig {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{FederationVersion, SchemaSource, SubgraphConfig};
-
-    use super::SupergraphConfig;
+    use std::{collections::BTreeMap, convert::TryFrom, fs};
 
     use assert_fs::TempDir;
     use camino::Utf8PathBuf;
     use semver::Version;
-    use std::collections::BTreeMap;
-    use std::convert::TryFrom;
-    use std::fs;
+
+    use crate::config::{FederationVersion, SchemaSource, SubgraphConfig};
+
+    use super::SupergraphConfig;
 
     #[test]
     fn it_can_parse_valid_config_without_version() {
@@ -731,5 +728,24 @@ subgraphs:
         ]);
 
         assert_eq!(base_config.subgraphs, expected_subgraphs);
+    }
+
+    #[test]
+    fn test_supergraph_config_from_iterator() {
+        let iter = [(
+            "subgraph_tmp".to_string(),
+            SubgraphConfig {
+                routing_url: Some("url".to_string()),
+                schema: SchemaSource::Sdl {
+                    sdl: "subgraph_tmp".to_string(),
+                },
+            },
+        )]
+        .into_iter();
+
+        let s: SupergraphConfig = iter.collect();
+        assert_eq!(None, s.get_federation_version());
+        assert!(s.get_subgraph_definitions().is_ok());
+        assert_eq!(1, s.get_subgraph_definitions().unwrap().len());
     }
 }

--- a/apollo-federation-types/src/config/supergraph.rs
+++ b/apollo-federation-types/src/config/supergraph.rs
@@ -164,6 +164,19 @@ impl IntoIterator for SupergraphConfig {
     }
 }
 
+impl FromIterator<(String, SubgraphConfig)> for SupergraphConfig {
+    fn from_iter<T: IntoIterator<Item=(String, SubgraphConfig)>>(iter: T) -> Self {
+        let mut subgraphs = BTreeMap::new();
+        for (name, subgraph_config) in iter {
+            subgraphs.insert(name, subgraph_config);
+        }
+        Self {
+            subgraphs,
+            federation_version: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::{FederationVersion, SchemaSource, SubgraphConfig};


### PR DESCRIPTION
Adds a simple method in order to construct a SuperGraph config out of an Iterator of String and Subgraph Configs. Essentially the reverse of the IntoIterator method implemented above.