### PR TITLE
Add EntityResolverArgumentMismatch error code

### DIFF
--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -209,6 +209,7 @@ fn transform_code(code: Code) -> String {
         Code::MultipleHttpMethods => "MULTIPLE_HTTP_METHODS",
         Code::MissingHttpMethod => "MISSING_HTTP_METHOD",
         Code::EntityNotOnRootQuery => "ENTITY_NOT_ON_ROOT_QUERY",
+        Code::EntityResolverArgumentMismatch => "ENTITY_RESOLVER_ARGUMENT_MISMATCH",
         Code::EntityTypeInvalid => "ENTITY_TYPE_INVALID",
         Code::InvalidJsonSelection => "INVALID_JSON_SELECTION",
         Code::CircularReference => "CIRCULAR_REFERENCE",


### PR DESCRIPTION
Add the error type emitted by #apollographql/router/pull/5984. Cannot be merged (and build will fail) until that dependency PR is merged.