### PR TITLE
Make `SubgraphLocation.subgraph` an `Option`

### DIFF
--- a/apollo-composition/CHANGELOG.md
+++ b/apollo-composition/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNEXT
+
+- [#586](https://github.com/apollographql/federation-rs/pull/586) Make
+  `SubgraphLocation.subgraph` an `Option`. For now, composition errors can have
+  no attributed subgraph.
+
 ## 0.1.2
 
-* Updated dependencies
+- Updated dependencies

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -82,7 +82,7 @@ pub trait HybridComposition {
                         .locations
                         .into_iter()
                         .map(|range| SubgraphLocation {
-                            subgraph: subgraph.name.clone(),
+                            subgraph: Some(subgraph.name.clone()),
                             range: Some(range),
                         })
                         .collect(),
@@ -181,7 +181,10 @@ pub struct Issue {
 /// A location in a subgraph's SDL
 #[derive(Clone, Debug)]
 pub struct SubgraphLocation {
-    pub subgraph: String,
+    /// This field is an Option to support the lack of subgraph names in
+    /// existing composition errors. New composition errors should always
+    /// include a subgraph name.
+    pub subgraph: Option<String>,
     pub range: Option<Range<LineColumn>>,
 }
 
@@ -268,7 +271,7 @@ impl From<Issue> for BuildMessage {
 impl From<SubgraphLocation> for BuildMessageLocation {
     fn from(location: SubgraphLocation) -> Self {
         BuildMessageLocation {
-            subgraph: Some(location.subgraph),
+            subgraph: location.subgraph,
             start: location.range.as_ref().map(|range| BuildMessagePoint {
                 line: Some(range.start.line),
                 column: Some(range.start.column),
@@ -290,7 +293,7 @@ impl From<SubgraphLocation> for BuildMessageLocation {
 impl SubgraphLocation {
     fn from_ast(node: SubgraphASTNode) -> Option<Self> {
         Some(Self {
-            subgraph: node.subgraph?,
+            subgraph: node.subgraph,
             range: node.loc.and_then(|node_loc| {
                 Some(Range {
                     start: LineColumn {
@@ -400,7 +403,7 @@ impl From<BuildHint> for Issue {
 impl From<BuildMessageLocation> for SubgraphLocation {
     fn from(location: BuildMessageLocation) -> Self {
         Self {
-            subgraph: location.subgraph.unwrap_or_default(),
+            subgraph: location.subgraph,
             range: location.start.and_then(|start| {
                 let end = location.end?;
                 Some(Range {


### PR DESCRIPTION
Make `SubgraphLocation.subgraph` an `Option`. For now, composition errors can have no attributed subgraph.