### PR TITLE
Fix deserialization of GraphQLError nodes

### DIFF
--- a/apollo-composition/CHANGELOG.md
+++ b/apollo-composition/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- [#590](https://github.com/apollographql/federation-rs/pull/590) Fix
+  deserialization of `GraphQLError` nodes.
+
 ## 0.1.4
 
 - Update to `apollo-federation` 2.0.0-preview.0

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -317,6 +317,7 @@ impl From<GraphQLError> for Issue {
             severity: Severity::Error,
             locations: error
                 .nodes
+                .unwrap_or_default()
                 .into_iter()
                 .filter_map(SubgraphLocation::from_ast)
                 .collect(),

--- a/apollo-federation-types/CHANGELOG.md
+++ b/apollo-federation-types/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Not every version is listed here because versions before 0.14.0 did not have a changelog.
 
+## 0.15.0 (Unreleased)
+
+### Breaking changes
+
+- `GraphQLError.nodes` is now an `Option<Vec<SubgraphASTNode>>`
+
 ## 0.14.1 - 2024-09-19
 
 ### Features

--- a/apollo-federation-types/src/javascript/mod.rs
+++ b/apollo-federation-types/src/javascript/mod.rs
@@ -61,8 +61,7 @@ pub struct Token {
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct GraphQLError {
     pub message: String,
-    #[serde(default)]
-    pub nodes: Vec<SubgraphASTNode>,
+    pub nodes: Option<Vec<SubgraphASTNode>>,
     pub extensions: Option<GraphQLErrorExtensions>,
 }
 


### PR DESCRIPTION
While attempting to deserialize certain composition errors, we ran into some errors which caused crashes. After some digging it was determined that it was due to the `nodes` key on `GraphQLError` being set as `undefined` in our JSON response.

In the fed-types crate, we attempt to use `#[serde(default)]` to handle this case, however as mentioned in #563, it only works when they key is not present. Instead we should handle it as an `Option` to account for its absence or rare `undefined` assignment.