### PR TITLE
Bump images for 2.9 release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ executors:
      XTASK_TARGET: "x86_64-unknown-linux-gnu"
   arm_ubuntu: &arm_ubuntu_executor
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2004:2024.01.1
     resource_class: arm.large
     environment:
       XTASK_TARGET: "aarch64-unknown-linux-gnu"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,9 +300,6 @@ commands:
               - equal: [ *arm_macos_executor, << parameters.platform >> ]
           steps:
             - run:
-                name: Skip homebrew update
-                command: echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
-            - run:
                 name: Install CMake
                 command: |
                   brew install cmake


### PR DESCRIPTION
This PR:
- Bumps the Ubuntu image to the same used in Router ([Router did the bump to avoid CI brownouts](https://github.com/apollographql/router/pull/4735)).
  - We were seeing the same CI brownouts, so we're doing the same.
- Stops skipping `brew` update when installing `cmake` ([Router never did this apparently](https://github.com/apollographql/router/blob/c5a3e5b66693fef5f62e350a00469da5e1d3370f/.circleci/config.yml#L251)).
  - This makes builds take longer, but without it we're seeing `brew` errors when installing `cmake`.