### PR TITLE
update federation-types/composition version

### DIFF
--- a/apollo-composition/Cargo.toml
+++ b/apollo-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-composition"
-version = "0.3.0"
+version = "0.3.1"
 license = "Elastic-2.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
@@ -11,7 +11,7 @@ repository = "https://github.com/apollographql/federation-rs/"
 [dependencies]
 apollo-compiler = { workspace = true }
 apollo-federation = { workspace = true }
-apollo-federation-types = { version = "0.15.3", path = "../apollo-federation-types", features = [
+apollo-federation-types = { version = "0.15.4", path = "../apollo-federation-types", features = [
   "composition",
 ] }
 either = "1.12.0"

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.15.3"
+version = "0.15.4"
 
 [features]
 default = ["config", "build", "build_plugin"]


### PR DESCRIPTION
Updating `Cargo.toml` files to latest versions

* `apollo-federation-types` 0.15.4
* `apollo-composition` 0.3.1