### PR TITLE
deps: update schemars to v1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",

--- a/apollo-federation-types/CHANGELOG.md
+++ b/apollo-federation-types/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Not every version is listed here because versions before 0.14.0 did not have a changelog.
 
+## 0.15.8
+
+### Features
+
+- Update `schemars` dependency crate to v1.0.4 (from v0.8.21)
+
 ## 0.15.7
 
 ### Features
@@ -25,7 +31,6 @@ Not every version is listed here because versions before 0.14.0 did not have a c
 ### Features
 
 - In `RouterVersion`, rename `Latest` to `LastestOne` and add `LatestTwo`
-
 
 ## 0.15.2
 

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.15.7"
+version = "0.15.8"
 
 [features]
 default = ["config", "build", "build_plugin"]

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -26,7 +26,7 @@ apollo-federation = { workspace = true }
 
 # config and build dependencies
 serde = { version = "1", features = ["derive"] }
-schemars = { version = "1.0.0", optional = true, features = ["url2"] }
+schemars = { version = "1.0.4", optional = true, features = ["url2"] }
 
 # config-only dependencies
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
Following PR #637 where `schemars` was upgraded from v.0.8.21 to v1.0.0, this PR updates it to v1.0.4 which is the latest version. This is currently blocking Rover from updating in https://github.com/apollographql/rover/pull/2641.

