### PR TITLE
chore: fixed an unused import warning

### DIFF
--- a/apollo-federation-types/src/config/version.rs
+++ b/apollo-federation-types/src/config/version.rs
@@ -4,6 +4,7 @@ use semver::Version;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+#[cfg(feature = "json_schema")]
 use std::borrow::Cow;
 use std::{
     fmt::{self, Display},


### PR DESCRIPTION
- added `#[cfg(feature = "json_schema")]` on `use std::borrow::Cow`.