### PR TITLE
BREAKING CHANGE: update `HybridComposition` methods to use `Issue` type for hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "apollo-compiler",
  "apollo-federation",
  "apollo-federation-types",
- "either",
 ]
 
 [[package]]

--- a/apollo-composition/Cargo.toml
+++ b/apollo-composition/Cargo.toml
@@ -14,4 +14,3 @@ apollo-federation = { workspace = true }
 apollo-federation-types = { version = "0.16.0-preview.1", path = "../apollo-federation-types", features = [
   "composition",
 ] }
-either = "1.12.0"

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -17,9 +17,8 @@ use apollo_federation_types::composition::{
 };
 use apollo_federation_types::{
     composition::{Issue, Severity},
-    javascript::{SatisfiabilityResult, SubgraphDefinition},
+    javascript::SubgraphDefinition,
 };
-use either::Either;
 use std::collections::HashMap;
 use std::iter::once;
 use std::sync::Arc;
@@ -48,10 +47,10 @@ pub trait HybridComposition {
     ///
     /// # Output
     ///
-    /// If satisfiability completes from JavaScript, the [`SatisfiabilityResult`] (matching the shape
-    /// of that function) should be returned. If Satisfiability _can't_ be run, you can return an
-    /// `Err(Issue)` instead indicating what went wrong.
-    async fn validate_satisfiability(&mut self) -> Result<SatisfiabilityResult, Issue>;
+    /// If satisfiability completes from JavaScript, either a list of hints (could be empty, the Ok case) or a list
+    /// of errors (never empty, the Err case) will be returned. If Satisfiability _can't_ be run, you can return a single error
+    /// (`Err(vec![Issue])`) indicating what went wrong.
+    async fn validate_satisfiability(&mut self) -> Result<Vec<Issue>, Vec<Issue>>;
 
     /// Allows the Rust composition code to modify the stored supergraph SDL
     /// (for example, to expand connectors).
@@ -393,7 +392,7 @@ pub trait HybridComposition {
         })
     }
 
-    /// If successful, returns a list of hints; Otherwise, returns a list of errors.
+    /// If successful, returns a list of hints (possibly empty); Otherwise, returns a list of errors.
     async fn experimental_validate_satisfiability(
         &mut self,
         supergraph_sdl: &str,
@@ -591,24 +590,11 @@ fn convert_severity(severity: ValidationSeverity) -> Severity {
 }
 
 fn satisfiability_result_into_issues(
-    satisfiability_result: Result<SatisfiabilityResult, Issue>,
-) -> Either<impl Iterator<Item = Issue>, impl Iterator<Item = Issue>> {
-    match satisfiability_result {
-        Ok(satisfiability_result) => Either::Left(
-            satisfiability_result
-                .errors
-                .into_iter()
-                .flatten()
-                .map(Issue::from)
-                .chain(
-                    satisfiability_result
-                        .hints
-                        .into_iter()
-                        .flatten()
-                        .map(Issue::from),
-                ),
-        ),
-        Err(issue) => Either::Right(once(issue)),
+    result: Result<Vec<Issue>, Vec<Issue>>,
+) -> impl Iterator<Item = Issue> {
+    match result {
+        Ok(hints) => hints.into_iter(),
+        Err(errors) => errors.into_iter(),
     }
 }
 

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -11,9 +11,10 @@ use apollo_federation::connectors::{
 use apollo_federation::internal_composition_api::validate_cache_tag_directives;
 use apollo_federation::subgraph::typestate::{Initial, Subgraph, Upgraded, Validated};
 use apollo_federation::subgraph::SubgraphError;
-use apollo_federation_types::build_plugin::{BuildMessage, PluginResult};
-use apollo_federation_types::composition::{convert_subraph_error_to_issues, SubgraphLocation};
-use apollo_federation_types::javascript::{CompositionHint, HintCodeDefinition, MergeResult};
+use apollo_federation_types::build_plugin::PluginResult;
+use apollo_federation_types::composition::{
+    convert_subraph_error_to_issues, MergeResult, SubgraphLocation,
+};
 use apollo_federation_types::{
     composition::{Issue, Severity},
     javascript::{SatisfiabilityResult, SubgraphDefinition},
@@ -264,7 +265,7 @@ pub trait HybridComposition {
                         let mut composition_hints = merge_result.hints;
                         composition_hints.extend(s);
 
-                        let mut build_messages: Vec<BuildMessage> =
+                        let mut build_messages: Vec<_> =
                             connector_hints.into_iter().map(|h| h.into()).collect();
                         build_messages.extend(composition_hints.into_iter().map(|h| {
                             let mut issue = Into::<Issue>::into(h);
@@ -290,7 +291,7 @@ pub trait HybridComposition {
                     let mut hints = merge_result.hints;
                     hints.extend(s);
 
-                    let build_messages: Vec<BuildMessage> = hints
+                    let build_messages: Vec<_> = hints
                         .into_iter()
                         .map(|h| Into::<Issue>::into(h).into())
                         .collect();
@@ -350,6 +351,7 @@ pub trait HybridComposition {
             .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())
     }
 
+    /// In case of a merge failure, returns a list of errors.
     async fn experimental_merge_subgraphs(
         &mut self,
         subgraphs: Vec<SubgraphDefinition>,
@@ -376,12 +378,13 @@ pub trait HybridComposition {
         let hints = supergraph
             .hints()
             .iter()
-            .map(|h| CompositionHint {
-                message: h.message.clone(),
-                definition: HintCodeDefinition {
+            .map(|h| {
+                Issue {
                     code: h.code.clone(),
-                },
-                nodes: None,
+                    message: h.message.clone(),
+                    locations: Default::default(), // TODO
+                    severity: Severity::Warning,
+                }
             })
             .collect();
         Ok(MergeResult {
@@ -390,21 +393,23 @@ pub trait HybridComposition {
         })
     }
 
+    /// If successful, returns a list of hints; Otherwise, returns a list of errors.
     async fn experimental_validate_satisfiability(
         &mut self,
         supergraph_sdl: &str,
-    ) -> Result<Vec<CompositionHint>, Vec<Issue>> {
+    ) -> Result<Vec<Issue>, Vec<Issue>> {
         let supergraph = Supergraph::parse(supergraph_sdl).map_err(|e| vec![Issue::from(e)])?;
         validate_satisfiability(supergraph)
             .map(|s| {
                 s.hints()
                     .iter()
-                    .map(|h| CompositionHint {
-                        message: h.message.clone(),
-                        definition: HintCodeDefinition {
+                    .map(|h| {
+                        Issue {
                             code: h.code.clone(),
-                        },
-                        nodes: None,
+                            message: h.message.clone(),
+                            locations: Default::default(), // TODO
+                            severity: Severity::Warning,
+                        }
                     })
                     .collect()
             })

--- a/apollo-federation-types/src/composition/mod.rs
+++ b/apollo-federation-types/src/composition/mod.rs
@@ -285,6 +285,12 @@ pub fn convert_subraph_error_to_issues(error: SubgraphError) -> Vec<Issue> {
         .collect()
 }
 
+#[derive(Debug, Clone)]
+pub struct MergeResult {
+    pub supergraph: String,
+    pub hints: Vec<Issue>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apollo-federation-types/src/javascript/mod.rs
+++ b/apollo-federation-types/src/javascript/mod.rs
@@ -29,13 +29,6 @@ pub struct SatisfiabilityResult {
     pub hints: Option<Vec<CompositionHint>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
-pub struct MergeResult {
-    pub supergraph: String,
-    #[serde(default)]
-    pub hints: Vec<CompositionHint>,
-}
-
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct CompositionHint {
     pub message: String,


### PR DESCRIPTION
### Background

We are anticipating our new Rust composition will be a drop-in replacement of HybridComposer. But, currently, `HybridComposition` trait is using the JS-specific `CompositionHint` type for hints (in both `MergeResult` and `SatisfiabilityResult`).

The problem is the Rust composition has to emulate the JS data structures as it currently stands. It will be much easier if the trait methods use the `Issue` type in the first place.

### Proposed Changes

This PR changes `HybridComposition` trait to use the `Issue` type directly, instead of JS `CompositionHint`. This is intended to be a pure refactoring. `CompositionHint` values from `HybridComposition` are immediately converted to `Issue` type anyways. We can use `Issue` type for API and do the conversion in the fedutils-build-plugin's implementation with no effective changes.

* changed `MergeResult` to use `Issue` type.
  * This is only used for `experimental_` methods. So, this is not a breaking change.
* moved `MergeResult` from `javascript` module to `composition` module, since it does not concern JS serialization.
* changed `validate_satisfiability` trait method to return `Vec<Issue>`, instead of `SatisfiabilityResult`.
  * This is technically a breaking change, but it shouldn't be used outside of this apollo-composition & fbp and not visible to customers.
  * If we want to keep the API in the main branch, we can target `next` branch, instead.
  * Note: The method previously returned `Result<SatisfiabilityResult, Issue>`, which really had 3 cases -- success with optional JS hints, satisfiability error with a list of JS errors, or deno error with one `Issue`. This PR conflates the latter two as `Err(Vec<Issue>)`. I think that's ok since the downstream usage of this method does not really distinguish those cases.

Companion PR on fbp repo: https://github.com/mdg-private/fedutils-build-plugins/pull/151