### PR TITLE
Updates for `apollo-federation@2.6.0-preview.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-composition"
-version = "0.4.0-preview.4"
+version = "0.4.0-preview.5"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.6.0-preview.1"
+version = "2.6.0-preview.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56db4ca6fe6dfcba2e75819c29e6e1965c75ba3244cb1fa83e407518ea788d3"
+checksum = "e74fb465bb96d6e82cc5243d1c9668d9fce6b426a32b02bc7a2427b65d17b354"
 dependencies = [
  "apollo-compiler",
  "derive_more",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.16.0-preview.1"
+version = "0.16.0-preview.2"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ resolver = "2"
 
 [workspace.dependencies]
 apollo-compiler = "1.28.0"
-apollo-federation = "=2.6.0-preview.1"
+apollo-federation = "=2.6.0-preview.2"

--- a/apollo-composition/Cargo.toml
+++ b/apollo-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-composition"
-version = "0.4.0-preview.4"
+version = "0.4.0-preview.5"
 license = "Elastic-2.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
@@ -11,7 +11,7 @@ repository = "https://github.com/apollographql/federation-rs/"
 [dependencies]
 apollo-compiler = { workspace = true }
 apollo-federation = { workspace = true }
-apollo-federation-types = { version = "0.16.0-preview.1", path = "../apollo-federation-types", features = [
+apollo-federation-types = { version = "0.16.0-preview.2", path = "../apollo-federation-types", features = [
   "composition",
 ] }
 either = "1.12.0"

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.16.0-preview.1"
+version = "0.16.0-preview.2"
 
 [features]
 default = ["config", "build", "build_plugin"]


### PR DESCRIPTION
Analogous to #650, this PR aims to publish `apollo-composition@0.4.0-preview.5` and `apollo-federation-types@0.16.0-preview.2`, effectively updating to `apollo-federation@2.6.0-preview.2`, which includes my PR https://github.com/apollographql/router/pull/8074.