### PR TITLE
Version bumps for apollo-federation@2.6.0-preview.3 (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-composition"
-version = "0.4.0-preview.6"
+version = "0.4.0-preview.7"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.16.0-preview.3"
+version = "0.16.0-preview.4"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",

--- a/apollo-composition/Cargo.toml
+++ b/apollo-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-composition"
-version = "0.4.0-preview.6"
+version = "0.4.0-preview.7"
 license = "Elastic-2.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
@@ -11,6 +11,6 @@ repository = "https://github.com/apollographql/federation-rs/"
 [dependencies]
 apollo-compiler = { workspace = true }
 apollo-federation = { workspace = true }
-apollo-federation-types = { version = "0.16.0-preview.3", path = "../apollo-federation-types", features = [
+apollo-federation-types = { version = "0.16.0-preview.4", path = "../apollo-federation-types", features = [
   "composition",
 ] }

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.16.0-preview.3"
+version = "0.16.0-preview.4"
 
 [features]
 default = ["config", "build", "build_plugin"]


### PR DESCRIPTION
Analogous to #652 and #654, but this time including a merge of `next` into `main`, which I forgot when I published the previous preview versions. The underlying apollo-federation@2.6.0-preview.3 version is staying the same, since it hasn't changed.

New versions:
* apollo-composition@0.4.0-preview.7
* apollo-federation-types@0.16.0-preview.4