### PR TITLE
Delete `BuildErrorNodeLocation` struct

### DIFF
--- a/apollo-federation-types/src/rover/error.rs
+++ b/apollo-federation-types/src/rover/error.rs
@@ -41,11 +41,6 @@ impl From<BuildMessage> for BuildError {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BuildErrorNodeLocation {
-    subgraph: Option<String>,
-}
-
 impl BuildError {
     pub fn composition_error(
         code: Option<String>,


### PR DESCRIPTION
Removed `BuildErrorNodeLocation` struct from error.rs since it is not being used in this repo or others and is generating a linter error.