### PR TITLE
fix(harmonizer): fix CompositionError exception to format properly

### DIFF
--- a/harmonizer/src/lib.rs
+++ b/harmonizer/src/lib.rs
@@ -264,4 +264,31 @@ mod tests {
             .supergraph_sdl
         );
     }
+
+    #[test]
+    fn test_invalid_schema_error() {
+        use crate::{harmonize, SubgraphDefinition};
+
+        let errors: Vec<_> = harmonize(vec![SubgraphDefinition::new(
+            "A",
+            "http://A",
+            "invalid schema",
+        )])
+        .expect_err("parsing should fail")
+        .iter()
+        .map(|e| e.to_string())
+        .collect();
+
+        assert_eq!(errors.len(), 1);
+        insta::assert_snapshot!(
+            errors[0],
+            @r###"
+        INVALID_GRAPHQL: [A] - Syntax Error: Unexpected Name "invalid".
+
+        GraphQL request:1:1
+        1 | invalid schema
+          | ^
+        "###
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where harmonizer (v2.9) returns a `INVALID_GRAPHQL` error without formatting the message correctly. The error message would looke like this: `INVALID_GRAPHQL: [object Object]`.

This PR adds a type check for `CompositionError` and convert other types to `CompositionError`.