### PR TITLE
chore: update to apollo-federation/router 2.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-composition"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6cda42a8c302a0b26fcb50096e6932eb8bd31bec3a4e506e2b6825c584bc1c"
+checksum = "eab083d263f726db66538cb13c7dc3366bea3ce17b480ca8692e6b5a54fb81a4"
 dependencies = [
  "apollo-compiler",
  "derive_more",
@@ -76,6 +76,7 @@ dependencies = [
  "encoding_rs",
  "form_urlencoded",
  "hashbrown 0.16.0",
+ "heck",
  "http",
  "indexmap 2.11.4",
  "itertools",
@@ -104,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -926,12 +927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "multi_try"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,19 +943,18 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
 name = "nom_locate"
-version = "4.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
 dependencies = [
  "bytecount",
  "memchr",
@@ -1506,15 +1500,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,6 @@ resolver = "2"
 
 [workspace.dependencies]
 apollo-compiler = "1.31.0"
-apollo-federation = "2.13.1"
+# apollo-federation does not adhere to SemVer and should be exactly pinned so that
+# consumers of this crate don't end up incidentally updating with breaking changes
+apollo-federation = "=2.14.0"

--- a/apollo-composition/CHANGELOG.md
+++ b/apollo-composition/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.3
+
+- Provide default `apollo_federation::composition::CompositionOptions` to `merge_subgraphs` invocations to match the new API shape
+- Update `apollo-federation` dependency to v2.14.0 (from v2.13.1)
+
 ## 0.5.2
 
 - Map `@cacheTag` validation errors using `internal_composition_api::Message` accessors (`code()`, `message()`, `locations()`), matching the router `apollo-federation` crate after the cache-tag validation refactor.

--- a/apollo-composition/Cargo.toml
+++ b/apollo-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-composition"
-version = "0.5.2"
+version = "0.5.3"
 license = "Elastic-2.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
@@ -11,6 +11,6 @@ repository = "https://github.com/apollographql/federation-rs/"
 [dependencies]
 apollo-compiler = { workspace = true }
 apollo-federation = { workspace = true }
-apollo-federation-types = { version = "0.17.2", path = "../apollo-federation-types", features = [
+apollo-federation-types = { version = "0.17.3", path = "../apollo-federation-types", features = [
   "composition",
 ] }

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -1,7 +1,7 @@
 use apollo_compiler::{schema::ExtendedType, Schema};
 use apollo_federation::composition::{
     expand_subgraphs, merge_subgraphs, post_merge_validations, pre_merge_validations,
-    upgrade_subgraphs_if_necessary, validate_satisfiability, Supergraph,
+    upgrade_subgraphs_if_necessary, validate_satisfiability, CompositionOptions, Supergraph,
 };
 use apollo_federation::connectors::{
     expand::{expand_connectors, Connectors, ExpansionResult},
@@ -313,7 +313,7 @@ pub trait HybridComposition {
         }
         pre_merge_validations(&validated)
             .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())?;
-        let supergraph = merge_subgraphs(validated)
+        let supergraph = merge_subgraphs(validated, &CompositionOptions::default())
             .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())?;
         post_merge_validations(&supergraph)
             .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())?;
@@ -334,7 +334,7 @@ pub trait HybridComposition {
         supergraph_sdl: &str,
     ) -> Result<Vec<Issue>, Vec<Issue>> {
         let supergraph = Supergraph::parse(supergraph_sdl).map_err(|e| vec![Issue::from(e)])?;
-        validate_satisfiability(supergraph)
+        validate_satisfiability(supergraph, &CompositionOptions::default())
             .map(|s| s.hints().iter().map(|h| h.clone().into()).collect())
             .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())
     }

--- a/apollo-federation-types/CHANGELOG.md
+++ b/apollo-federation-types/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Not every version is listed here because versions before 0.14.0 did not have a changelog.
 
+## 0.17.3
+
+- Switch to accessor `code()` method when extracting hint codes from `native::CompositionHint`
+- Update `apollo-federation` dependency to v2.14.0 (from v2.13.1)
+
 ## 0.17.1
 
 - Update `apollo-federation` dependency to v2.13.1 (from v2.12.0)

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.17.2"
+version = "0.17.3"
 
 [features]
 default = ["config", "build", "build_plugin"]

--- a/apollo-federation-types/src/composition/mod.rs
+++ b/apollo-federation-types/src/composition/mod.rs
@@ -135,7 +135,7 @@ impl From<CompositionError> for Issue {
 impl From<native::CompositionHint> for Issue {
     fn from(hint: native::CompositionHint) -> Self {
         Issue {
-            code: hint.code,
+            code: hint.code().to_owned(),
             message: hint.message,
             locations: convert_subgraph_locations(hint.locations),
             severity: Severity::Warning,


### PR DESCRIPTION
I also changed it so that the apollo-federation crate is pinned to its exact version, which will prevent Rover from transitively pulling in newer apollo-federation versions early before this crate is updated to work with them.
