### PR TITLE
chore: update to apollo-federation/router 2.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.31.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e0b71d829a6eec7900cab1ef14791290a3b2edf201dbc7c56cae5ef001475d"
+checksum = "b877306ffde4d3cc428bbc8f506fdd67b99255298ae92b919954c0c52f530504"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-composition"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab083d263f726db66538cb13c7dc3366bea3ce17b480ca8692e6b5a54fb81a4"
+checksum = "d244561ed6636188ecf93629656ab362d51341b41d85dc09bf7e22b16d8dd41c"
 dependencies = [
  "apollo-compiler",
  "derive_more",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation-types"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "apollo-compiler",
  "apollo-federation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -35,12 +35,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apollo-compiler"
@@ -130,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947e21ff51879f8a40d7519dfe619268de2afba4042a8a43878276de3cb910f0"
+checksum = "11f6e2be4b3474e5890d34d3e483d49ec9b5cbf9e358bc62c9cc5423376df54b"
 dependencies = [
  "memchr",
  "rowan",
@@ -152,12 +146,11 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+checksum = "6ecf5c70ca07b7f80220bce936f0556a960ca6fb00fc2bd4125b5e581b218137"
 dependencies = [
  "anstyle",
- "doc-comment",
  "globwalk",
  "predicates",
  "predicates-core",
@@ -167,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -179,9 +172,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -383,20 +376,14 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "dyn-clone"
@@ -406,9 +393,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -541,9 +528,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -580,21 +567,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -622,7 +596,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "ignore",
  "walkdir",
 ]
@@ -661,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -679,9 +653,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -770,12 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -835,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -880,12 +848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,9 +855,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "line-col"
@@ -932,15 +894,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -985,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num_threads"
@@ -1138,16 +1100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,18 +1133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -1313,7 +1259,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1420,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -1449,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "serde_core",
  "serde_with_macros",
@@ -1459,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1575,7 +1521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1675,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -1743,9 +1688,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -1761,9 +1706,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -1818,50 +1763,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1956,20 +1858,11 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -1977,85 +1870,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -2103,18 +1917,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2123,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ resolver = "2"
 apollo-compiler = "1.31.0"
 # apollo-federation does not adhere to SemVer and should be exactly pinned so that
 # consumers of this crate don't end up incidentally updating with breaking changes
-apollo-federation = "=2.14.0"
+apollo-federation = "=2.15.0"

--- a/apollo-composition/CHANGELOG.md
+++ b/apollo-composition/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## 0.5.4
+
+- For the `HybridComposition` trait, the default method implementations for `experimental_upgrade_subgraphs`, `experimental_merge_subgraphs`, and `experimental_validate_satisfiability` now contain both errors and hints in the `Err` case.
+- Update `apollo-federation` dependency to v2.14.0 (from v2.13.1)
+
 ## 0.5.3
 
 - Provide default `apollo_federation::composition::CompositionOptions` to `merge_subgraphs` invocations to match the new API shape
-- Update `apollo-federation` dependency to v2.14.0 (from v2.13.1)
+- Update `apollo-federation` dependency to v2.15.0 (from v2.14.0)
 
 ## 0.5.2
 

--- a/apollo-composition/CHANGELOG.md
+++ b/apollo-composition/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 0.5.4
 
 - For the `HybridComposition` trait, the default method implementations for `experimental_upgrade_subgraphs`, `experimental_merge_subgraphs`, and `experimental_validate_satisfiability` now contain both errors and hints in the `Err` case.
-- Update `apollo-federation` dependency to v2.14.0 (from v2.13.1)
+- Update `apollo-federation` dependency to v2.15.0 (from v2.14.0)
 
 ## 0.5.3
 
 - Provide default `apollo_federation::composition::CompositionOptions` to `merge_subgraphs` invocations to match the new API shape
-- Update `apollo-federation` dependency to v2.15.0 (from v2.14.0)
+- Update `apollo-federation` dependency to v2.14.0 (from v2.13.1)
 
 ## 0.5.2
 

--- a/apollo-composition/Cargo.toml
+++ b/apollo-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-composition"
-version = "0.5.3"
+version = "0.5.4"
 license = "Elastic-2.0"
 edition = "2021"
 authors = ["Apollo Developers <opensource@apollographql.com>"]
@@ -11,6 +11,6 @@ repository = "https://github.com/apollographql/federation-rs/"
 [dependencies]
 apollo-compiler = { workspace = true }
 apollo-federation = { workspace = true }
-apollo-federation-types = { version = "0.17.3", path = "../apollo-federation-types", features = [
+apollo-federation-types = { version = "0.17.5", path = "../apollo-federation-types", features = [
   "composition",
 ] }

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -1,13 +1,15 @@
 use apollo_compiler::{schema::ExtendedType, Schema};
 use apollo_federation::composition::{
     expand_subgraphs, merge_subgraphs, post_merge_validations, pre_merge_validations,
-    upgrade_subgraphs_if_necessary, validate_satisfiability, CompositionFailure, Supergraph,
+    upgrade_subgraphs_if_necessary, validate_satisfiability, CompositionFailure, Merged,
+    Supergraph,
 };
 use apollo_federation::connectors::{
     expand::{expand_connectors, Connectors, ExpansionResult},
     validation::{validate, Severity as ValidationSeverity, ValidationResult},
     Connector,
 };
+use apollo_federation::error::CompositionError;
 use apollo_federation::internal_composition_api::validate_cache_tag_directives;
 use apollo_federation::subgraph::typestate::{Initial, Subgraph, Validated};
 use apollo_federation::subgraph::SubgraphError;
@@ -175,9 +177,6 @@ pub trait HybridComposition {
     where
         Self: Sized,
     {
-        // `@cacheTag` directive validation
-        validate_cache_tag_in_subgraphs(&subgraph_definitions)?;
-
         // connectors validations
         // Any issues with overrides are fatal since they'll cause errors in expansion,
         // so we return early if we see any.
@@ -188,14 +187,9 @@ pub trait HybridComposition {
             hints: connector_hints,
         } = validate_connector_subgraphs(subgraph_definitions)?;
 
-        let upgraded_subgraphs = self
-            .experimental_upgrade_subgraphs(connected_subgraphs)
-            .await?;
-
-        // merge
-        let merge_result = self
-            .experimental_merge_subgraphs(upgraded_subgraphs)
-            .await?;
+        let merged_supergraph =
+            Self::experimental_compose_without_satisfiability(connected_subgraphs)
+                .map_err(failure_to_issues)?;
 
         // Extra connectors validation after merging.
         // - So that connectors-related override errors will only be reported if merging was
@@ -206,7 +200,12 @@ pub trait HybridComposition {
         }
 
         // expand connectors as needed
-        let supergraph_sdl = merge_result.supergraph.clone();
+        let supergraph_sdl = merged_supergraph.schema().schema().to_string();
+        let merge_hints: Vec<Issue> = merged_supergraph
+            .hints()
+            .iter()
+            .map(|hint| hint.clone().into())
+            .collect();
         let expansion_result = match expand_connectors(&supergraph_sdl, &Default::default()) {
             Ok(result) => result,
             Err(err) => {
@@ -223,11 +222,13 @@ pub trait HybridComposition {
                 },
                 ..
             } => {
-                self.experimental_validate_satisfiability(raw_sdl.as_str())
+                match self
+                    .experimental_validate_satisfiability(raw_sdl.as_str())
                     .await
-                    .map(|s| {
-                        let mut composition_hints = merge_result.hints;
-                        composition_hints.extend(s);
+                {
+                    Ok(sat_hints) => {
+                        let mut composition_hints = merge_hints;
+                        composition_hints.extend(sat_hints);
 
                         let mut build_messages: Vec<_> =
                             connector_hints.into_iter().map(|h| h.into()).collect();
@@ -236,31 +237,41 @@ pub trait HybridComposition {
                             sanitize_connectors_issue(&mut issue, by_service_name.iter());
                             issue.into()
                         }));
-                        // return original supergraph
-                        PluginResult::new(Ok(supergraph_sdl), build_messages)
-                    })
-                    .map_err(|err| {
-                        err.into_iter()
+                        Ok(PluginResult::new(Ok(supergraph_sdl), build_messages))
+                    }
+                    Err(mut issues) => {
+                        issues.extend(merge_hints);
+                        Err(issues
+                            .into_iter()
                             .map(|mut issue| {
                                 sanitize_connectors_issue(&mut issue, by_service_name.iter());
                                 issue
                             })
-                            .collect()
-                    })
+                            .collect())
+                    }
+                }
             }
-            ExpansionResult::Unchanged => self
-                .experimental_validate_satisfiability(supergraph_sdl.as_str())
-                .await
-                .map(|s| {
-                    let mut hints = merge_result.hints;
-                    hints.extend(s);
+            ExpansionResult::Unchanged => {
+                match self
+                    .experimental_validate_satisfiability(supergraph_sdl.as_str())
+                    .await
+                {
+                    Ok(sat_hints) => {
+                        let mut hints = merge_hints;
+                        hints.extend(sat_hints);
 
-                    let build_messages: Vec<_> = hints
-                        .into_iter()
-                        .map(|h| Into::<Issue>::into(h).into())
-                        .collect();
-                    PluginResult::new(Ok(supergraph_sdl), build_messages)
-                }),
+                        let build_messages: Vec<_> = hints
+                            .into_iter()
+                            .map(|h| Into::<Issue>::into(h).into())
+                            .collect();
+                        Ok(PluginResult::new(Ok(supergraph_sdl), build_messages))
+                    }
+                    Err(mut issues) => {
+                        issues.extend(merge_hints);
+                        Err(issues)
+                    }
+                }
+            }
         }
     }
 
@@ -288,14 +299,11 @@ pub trait HybridComposition {
             return Err(issues);
         }
         expand_subgraphs(initial)
-            .and_then(|graph| {
-                upgrade_subgraphs_if_necessary(graph).map_err(|errors| CompositionFailure {
-                    errors,
-                    hints: Vec::new(),
-                })
+            .and_then(|subgraphs| {
+                upgrade_subgraphs_if_necessary(subgraphs).map_err(CompositionFailure::from_errors)
             })
             .map(|subgraphs| subgraphs.into_iter().map(|s| s.into()).collect())
-            .map_err(|failure| composition_failure_into_issues(failure).collect())
+            .map_err(failure_to_issues)
     }
 
     /// In case of a merge failure, returns a list of errors.
@@ -316,12 +324,10 @@ pub trait HybridComposition {
             // this should never happen
             return Err(subgraph_errors);
         }
-        pre_merge_validations(&validated)
-            .map_err(|failure| composition_failure_into_issues(failure).collect::<Vec<_>>())?;
-        let supergraph = merge_subgraphs(validated, &Default::default())
-            .map_err(|failure| composition_failure_into_issues(failure).collect::<Vec<_>>())?;
-        post_merge_validations(&supergraph)
-            .map_err(|failure| composition_failure_into_issues(failure).collect::<Vec<_>>())?;
+        pre_merge_validations(&validated).map_err(failure_to_issues)?;
+        let supergraph =
+            merge_subgraphs(validated, &Default::default()).map_err(failure_to_issues)?;
+        post_merge_validations(&supergraph).map_err(failure_to_issues)?;
         let hints = supergraph
             .hints()
             .iter()
@@ -333,7 +339,8 @@ pub trait HybridComposition {
         })
     }
 
-    /// If successful, returns a list of hints (possibly empty); Otherwise, returns a list of errors.
+    /// If successful, returns a list of hints (possibly empty); Otherwise, returns a list of
+    /// errors and hints (as WARN-level issues).
     async fn experimental_validate_satisfiability(
         &mut self,
         supergraph_sdl: &str,
@@ -341,17 +348,33 @@ pub trait HybridComposition {
         let supergraph = Supergraph::parse(supergraph_sdl).map_err(|e| vec![Issue::from(e)])?;
         validate_satisfiability(supergraph, &Default::default())
             .map(|s| s.hints().iter().map(|h| h.clone().into()).collect())
-            .map_err(|failure| composition_failure_into_issues(failure).collect())
+            .map_err(failure_to_issues)
     }
-}
 
-fn composition_failure_into_issues(
-    CompositionFailure { errors, hints }: CompositionFailure,
-) -> impl Iterator<Item = Issue> {
-    errors
-        .into_iter()
-        .map(Issue::from)
-        .chain(hints.into_iter().map(Issue::from))
+    fn experimental_compose_without_satisfiability(
+        subgraphs: Vec<SubgraphDefinition>,
+    ) -> Result<Supergraph<Merged>, CompositionFailure> {
+        let mut errors: Vec<CompositionError> = vec![];
+        let initial: Vec<Subgraph<Initial>> = subgraphs
+            .into_iter()
+            .map(|s| s.try_into())
+            .filter_map(|r| {
+                r.map_err(|e: SubgraphError| errors.extend(e.to_composition_errors()))
+                    .ok()
+            })
+            .collect();
+        if !errors.is_empty() {
+            return Err(CompositionFailure::from_errors(errors));
+        }
+
+        let expanded_subgraphs = expand_subgraphs(initial)?;
+        let validated_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)
+            .map_err(CompositionFailure::from_errors)?;
+        pre_merge_validations(&validated_subgraphs)?;
+        let supergraph = merge_subgraphs(validated_subgraphs, &Default::default())?;
+        post_merge_validations(&supergraph)?;
+        Ok(supergraph)
+    }
 }
 
 struct SubgraphSchema {
@@ -578,6 +601,12 @@ fn satisfiability_result_into_issues(
         Ok(hints) => hints.into_iter(),
         Err(errors) => errors.into_iter(),
     }
+}
+
+fn failure_to_issues(failure: CompositionFailure) -> Vec<Issue> {
+    let mut issues: Vec<Issue> = failure.errors.into_iter().map(Issue::from).collect();
+    issues.extend(failure.hints.into_iter().map(Issue::from));
+    issues
 }
 
 // converts subgraph definitions to Subgraph<Validated> by assuming schema is already

--- a/apollo-composition/src/lib.rs
+++ b/apollo-composition/src/lib.rs
@@ -1,7 +1,7 @@
 use apollo_compiler::{schema::ExtendedType, Schema};
 use apollo_federation::composition::{
     expand_subgraphs, merge_subgraphs, post_merge_validations, pre_merge_validations,
-    upgrade_subgraphs_if_necessary, validate_satisfiability, Supergraph,
+    upgrade_subgraphs_if_necessary, validate_satisfiability, CompositionFailure, Supergraph,
 };
 use apollo_federation::connectors::{
     expand::{expand_connectors, Connectors, ExpansionResult},
@@ -288,9 +288,14 @@ pub trait HybridComposition {
             return Err(issues);
         }
         expand_subgraphs(initial)
-            .and_then(upgrade_subgraphs_if_necessary)
+            .and_then(|graph| {
+                upgrade_subgraphs_if_necessary(graph).map_err(|errors| CompositionFailure {
+                    errors,
+                    hints: Vec::new(),
+                })
+            })
             .map(|subgraphs| subgraphs.into_iter().map(|s| s.into()).collect())
-            .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())
+            .map_err(|failure| composition_failure_into_issues(failure).collect())
     }
 
     /// In case of a merge failure, returns a list of errors.
@@ -312,11 +317,11 @@ pub trait HybridComposition {
             return Err(subgraph_errors);
         }
         pre_merge_validations(&validated)
-            .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())?;
+            .map_err(|failure| composition_failure_into_issues(failure).collect::<Vec<_>>())?;
         let supergraph = merge_subgraphs(validated, &Default::default())
-            .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())?;
+            .map_err(|failure| composition_failure_into_issues(failure).collect::<Vec<_>>())?;
         post_merge_validations(&supergraph)
-            .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())?;
+            .map_err(|failure| composition_failure_into_issues(failure).collect::<Vec<_>>())?;
         let hints = supergraph
             .hints()
             .iter()
@@ -336,8 +341,17 @@ pub trait HybridComposition {
         let supergraph = Supergraph::parse(supergraph_sdl).map_err(|e| vec![Issue::from(e)])?;
         validate_satisfiability(supergraph, &Default::default())
             .map(|s| s.hints().iter().map(|h| h.clone().into()).collect())
-            .map_err(|errors| errors.into_iter().map(Issue::from).collect::<Vec<_>>())
+            .map_err(|failure| composition_failure_into_issues(failure).collect())
     }
+}
+
+fn composition_failure_into_issues(
+    CompositionFailure { errors, hints }: CompositionFailure,
+) -> impl Iterator<Item = Issue> {
+    errors
+        .into_iter()
+        .map(Issue::from)
+        .chain(hints.into_iter().map(Issue::from))
 }
 
 struct SubgraphSchema {

--- a/apollo-federation-types/CHANGELOG.md
+++ b/apollo-federation-types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.5
+
+- Update `apollo-federation` dependency to v2.15.0 (from v2.14.0)
+
 Not every version is listed here because versions before 0.14.0 did not have a changelog.
 
 ## 0.17.4

--- a/apollo-federation-types/Cargo.toml
+++ b/apollo-federation-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "apollo-federation-types"
 readme = "README.md"
 repository = "https://github.com/apollographql/federation-rs/"
-version = "0.17.4"
+version = "0.17.5"
 
 [features]
 default = ["config", "build", "build_plugin"]


### PR DESCRIPTION
Updates `apollo-federation` to `=2.15.0`, bumps `apollo-composition` to `0.5.4` and `apollo-federation-types` to `0.17.5`.

Part of the federation 2.15 release.

Changes
For the `HybridComposition` trait, the default method implementations for `experimental_upgrade_subgraphs`, `experimental_merge_subgraphs`, and `experimental_validate_satisfiability` now contain both errors and hints in the `Err` case.